### PR TITLE
feat: add Claude Code plugin support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "stop-that-shit",
+  "owner": {
+    "name": "Stop That Shit contributors"
+  },
+  "metadata": {
+    "description": "Local marketplace for Stop That Shit: keep agents on task with scope, dependency, hash, and delegation guardrails."
+  },
+  "plugins": [
+    {
+      "name": "stop-that-shit",
+      "source": "./",
+      "description": "Keep Claude Code on task with local-first mode, scope, dependency, hash, and delegation guardrails."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "stop-that-shit",
+  "displayName": "Stop That Shit",
+  "version": "0.0.3",
+  "description": "Keep Claude Code on task with local-first mode, scope, dependency, hash, and delegation guardrails.",
+  "author": {
+    "name": "Stop That Shit contributors",
+    "url": "https://github.com/lennney"
+  },
+  "homepage": "https://github.com/lennney/stop-that-shit",
+  "repository": "https://github.com/lennney/stop-that-shit",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "codex",
+    "scope-control",
+    "overengineering",
+    "guardrail"
+  ],
+  "skills": "./skills/"
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stop-that-shit",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Stop unneeded scope, subagents, dependencies, and hashes in Codex tasks.",
   "author": {
     "name": "Stop That Shit contributors",
@@ -16,7 +16,7 @@
     "guardrail"
   ],
   "skills": "./skills/",
-  "hooks": "./hooks/hooks.json",
+  "hooks": "./hooks/codex-hooks.json",
   "interface": {
     "displayName": "Stop That Shit",
     "shortDescription": "Stop small Codex tasks from growing extra machinery.",

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 *.log
 .DS_Store
 Thumbs.db
+.claude/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,29 +1,40 @@
 # Architecture
 
-Stop That Shit 0.0.2 has two narrow deep modules: a host-independent control
-decision and a metadata-only runtime evidence sidecar.
+Stop That Shit has a host-independent control core and two thin host adapters:
+Codex and Claude Code.
 
 ```text
-Codex Hook JSON
-    -> Codex Adapter
-    -> ControlEvent v1
-    -> decision(contract, action)
-    -> Codex Hook response + RuntimeEvent v1
+Codex Hook JSON  ----> Codex Adapter  ---\
+                                      +--> ControlEvent v1
+Claude Hook JSON ----> Claude Adapter ---/        |
+                                                 v
+                                      decision(contract, action)
+                                                 |
+                         +-----------------------+----------------------+
+                         v                                              v
+                 host Hook response                            RuntimeEvent v1
 ```
 
 - `src/decision.cjs` contains host-independent decisions.
 - `src/contracts.cjs` parses the small prompt contract.
 - `src/controller.cjs` stores the current contract and applies decisions.
-- `src/adapters/codex-*.cjs` classify Codex events and render Hook responses.
-- `src/state.cjs` stores only per-session contract state.
+- `src/adapters/codex-*.cjs` classify Codex events and render Codex responses.
+- `src/adapters/claude-*.cjs` classify Claude Code events and render Claude Hook
+  responses.
+- `src/state.cjs` stores per-session contract state and serializes delegation
+  reservations so concurrent Hook processes cannot oversubscribe `agents=N`.
 - `src/runtime-audit.cjs` appends and reads metadata-only decision events.
 - `src/runtime-annotations.cjs` appends independent human labels.
 
-The packaged Codex manifest subscribes to two events: user prompt and before
-tool use. It does not add a `SubagentStart` Hook, track completed actions, build
-a dependency graph, restore semantic checkpoints, or judge code quality.
+Codex keeps the original two packaged events: `UserPromptSubmit` and
+`PreToolUse`. Claude Code packages `SessionStart`, `UserPromptSubmit`,
+`PreToolUse`, and `SubagentStart`. Only `PreToolUse` is used for hard action
+denial; lifecycle events inject or update the shared contract. Direct Skill
+invocation arrives through `UserPromptSubmit`, which also keeps arming working
+on hosts that do not expose the optional `UserPromptExpansion` event; the
+adapter retains its `UserPromptExpansion` handler for hosts that register it.
 
-Control state and observed response are deliberately separate:
+Control state and observed response remain deliberately separate:
 
 ```text
 OFF        no checks and no normal-action events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.0.3 — 2026-08-14 (Claude Code adaptation)
+
+- Added a Claude Code plugin manifest, local marketplace, shared Skill discovery,
+  and native Hook configuration without replacing the existing Codex package.
+- Added a thin Claude Code Adapter for `SessionStart`, `UserPromptSubmit`,
+  `PreToolUse`, and `SubagentStart`, all normalized into the existing
+  `ControlEvent v1`. Direct `/stop-that-shit:stop-that-shit ...` invocation is
+  handled in `UserPromptSubmit` so it stays armed on hosts without the
+  `UserPromptExpansion` event; the adapter retains its optional
+  `UserPromptExpansion` handler, but the packaged `hooks/hooks.json` registers
+  only events every supported host accepts.
+- Added Claude-native tool classification for `Write`, `Edit`, `NotebookEdit`,
+  `EnterWorktree`, `Bash`, `PowerShell`, `Monitor`, `Agent`, current read tools,
+  task/control tools, and conservative MCP/plugin fallbacks. `Workflow` is
+  treated as unbounded delegation instead of bypassing `agents=N`.
+- Added POSIX/Windows absolute-path normalization, manifest dependency detection,
+  and process-safe delegation reservations so parallel agent launches respect
+  `agents=N`.
+- Preserved the original Codex two-Hook surface in `hooks/codex-hooks.json` and
+  kept the controller, policy, runtime evidence, cases, and Skill shared.
+- Added Claude adapter, plugin-structure, entrypoint, file-lock, dependency,
+  subagent, lifecycle, and parallel-budget regression tests.
+
 ## 0.0.2 — 2026-08-14 (Technical Preview 2)
 
 - Added `OFF`, `OBSERVING`, and `ARMED` control states with distinct context and

--- a/EVIDENCE.md
+++ b/EVIDENCE.md
@@ -1,9 +1,27 @@
 # Evidence
 
-Version: 0.0.2 Technical Preview 2
+Version: 0.0.3
 Release: https://github.com/lennney/stop-that-shit/releases/tag/0.0.2
 Tagged commit: `a5c937045e8a8de75e897459e4ba5f6c2cc9ae81`
 Last updated: 2026-08-14
+
+This tree is validated with deterministic Hook-schema simulations, real
+child-process stdin/stdout entrypoint tests, cross-platform path regression
+tests, and shared policy tests:
+
+- 115/115 runtime/unit/integration tests pass, including the preserved Codex
+  tests and Claude child-process Hook simulations;
+- 14/14 executable Bad/Good policy case arms pass;
+- Claude review-mode denial, namespaced slash-command arming, POSIX/Windows path
+  normalization, `NotebookEdit`, `PowerShell`, `Monitor`, `EnterWorktree`, and
+  `Workflow` fan-out handling have dedicated regressions;
+- two independent Claude Hook processes cannot oversubscribe `agents=1`;
+- all checked-in `.cjs` files pass `node --check`, all JSON files parse, and the
+  release allowlist passes with 109 files;
+- the generated CaseBundle validator and its schema were not changed;
+- on a local Windows host, `claude plugin validate` reported no warnings and a
+  live smoke session armed the Guard through both the `$stop-that-shit`
+  directive and the namespaced slash form, with a covered write denied.
 
 ## Published technical preview
 
@@ -147,7 +165,7 @@ were run after the null result.
 
 ## Not yet verified
 
-The following are explicit limitations, not 0.0.2 release blockers. The project
+The following are explicit limitations, not release blockers. The project
 does not require a large benchmark to make a probabilistic mitigation claim.
 
 - a multi-scenario live baseline/plugin matrix for the reduced candidate;
@@ -203,12 +221,12 @@ leading synthetic fixtures.
 
 ## Claim rule
 
-Do not claim that Stop That Shit solves Codex overengineering or publish an
+Do not claim that Stop That Shit solves agent overengineering or publish an
 improvement percentage from unit tests or this single scenario.
 
-The defensible 0.0.2 claim is:
+The defensible claim is:
 
-> Stop That Shit gives Codex a short on-demand decision ladder and enforces a
-> few explicit task-authority rules on covered Hook paths. It may reduce some
-> forms of execution drift, but it does not guarantee an effect on stochastic
-> model behavior.
+> Stop That Shit gives a coding agent a short on-demand decision ladder and
+> enforces a few explicit task-authority rules on covered Hook paths. It may
+> reduce some forms of execution drift, but it does not guarantee an effect on
+> stochastic model behavior.

--- a/EVIDENCE.md
+++ b/EVIDENCE.md
@@ -234,12 +234,12 @@ leading synthetic fixtures.
 
 ## Claim rule
 
-Do not claim that Stop That Shit solves agent overengineering or publish an
-improvement percentage from unit tests or this single scenario.
+Do not claim that Stop That Shit solves overengineering across coding agents or
+publish an improvement percentage from unit tests or this single scenario.
 
 The defensible 0.0.3 claim is:
 
-> Stop That Shit gives a coding agent a short on-demand decision ladder and
-> enforces a few explicit task-authority rules on covered Hook paths. It may
-> reduce some forms of execution drift, but it does not guarantee an effect on
-> stochastic model behavior.
+> In Codex, Claude Code, and OpenCode, Stop That Shit provides a short
+> on-demand decision ladder and enforces a few explicit task-authority rules on
+> covered Hook paths. It may reduce some forms of execution drift, but it does
+> not guarantee an effect on stochastic model behavior.

--- a/HOST-ADAPTER-CONTRACT.md
+++ b/HOST-ADAPTER-CONTRACT.md
@@ -1,7 +1,8 @@
 # Host Adapter Contract
 
-Codex is the only implemented Adapter in 0.0.2. This preserves a small future
-seam without pretending that unbuilt harnesses are supported.
+Stop That Shit has two implemented host adapters: Codex and Claude Code.
+Both normalize host events into the same `ControlEvent v1` and reuse the same
+contract parser, controller, decisions, state, and runtime evidence.
 
 An Adapter may reuse the decision module only if its host exposes:
 
@@ -10,11 +11,15 @@ An Adapter may reuse the decision module only if its host exposes:
 3. a before-action event that can actually deny an action;
 4. tool name, input, and enough information to classify mutability.
 
-Lifecycle context injection is optional. The current Codex package deliberately
-uses only user-prompt and before-action Hooks; it does not require or register a
-subagent-start Hook.
+Lifecycle context injection is optional. Codex deliberately keeps its original
+two-event surface (`UserPromptSubmit` and `PreToolUse`). Claude Code additionally
+uses `SessionStart` and `SubagentStart` because those host events provide useful
+context without changing the core policy. Direct Skill invocation is armed from
+`UserPromptSubmit`, so it works even on hosts that do not expose the
+`UserPromptExpansion` event; the adapter keeps its `UserPromptExpansion` handler
+for hosts that register it.
 
-The normalized event is versioned as `ControlEvent v1` and currently needs only:
+The normalized event is versioned as `ControlEvent v1`:
 
 ```json
 {
@@ -22,7 +27,7 @@ The normalized event is versioned as `ControlEvent v1` and currently needs only:
   "kind": "action.before",
   "sessionId": "opaque",
   "action": {
-    "name": "apply_patch",
+    "name": "Edit",
     "mutability": "write",
     "affectedPaths": ["src/config.cjs"],
     "dependencyIntent": false,
@@ -31,11 +36,41 @@ The normalized event is versioned as `ControlEvent v1` and currently needs only:
 }
 ```
 
+## Codex mapping
+
+`src/adapters/codex-hooks.cjs` maps the existing Codex Hook JSON to
+`ControlEvent v1`. The preserved Codex manifest points at
+`hooks/codex-hooks.json`, so Claude support does not broaden the original Codex
+Hook trust surface.
+
+## Claude Code mapping
+
+`src/adapters/claude-hooks.cjs` maps:
+
+```text
+SessionStart         -> session.start
+UserPromptSubmit     -> prompt.submit (also the /stop-that-shit:stop-that-shit slash form)
+PreToolUse            -> action.before
+SubagentStart         -> subagent.start
+UserPromptExpansion  -> prompt.submit (Stop That Shit Skill only; optional on hosts that expose it)
+```
+
+The Claude adapter returns a `PreToolUse` `permissionDecision: "deny"` when the
+shared controller denies an action. `SubagentStart` is context-only; `agents=N`
+is enforced before a Claude `Agent` tool runs, then the started subagent receives
+the active contract as additional context.
+
+The classifier covers Claude-native `Write`, `Edit`, `NotebookEdit`,
+`EnterWorktree`, `Bash`, `PowerShell`, `Monitor`, `Agent`, current read tools,
+and control/task tools. `Monitor` command sources reuse shell dependency/hash
+classification; WebSocket monitors are read-only. `Workflow` is treated as
+unbounded delegation and is denied by an armed Guard because its internal
+subagent fan-out cannot be proven to satisfy `agents=N`. MCP/plugin tool names
+fall back to the existing conservative name classifier. Explicit file locks
+normalize POSIX and Windows absolute paths relative to Hook `cwd` when possible.
+
 Host-specific event names, tool classification, paths, and response JSON belong
 inside the Adapter. Model identity is evaluation metadata, not a new Adapter.
 The Adapter may report that it returned context or permission deny, but it must
 not claim the host prevented execution without a separate completion signal.
 `RuntimeEvent v1` therefore records host effect as `unobserved`.
-
-One Adapter is still a hypothetical seam. Do not add another abstraction layer
-until a second real harness is implemented and passes the same Bad/Good cases.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,16 +1,41 @@
-# Install Stop That Shit 0.0.2
+# Install Stop That Shit
 
-The current immutable preview is
-[`0.0.2`](https://github.com/lennney/stop-that-shit/releases/tag/0.0.2).
+The default installation is the Guard: one shared Skill plus host Hook events.
+Install Skill only when you prefer advisory guidance without runtime
+enforcement.
 
-The default installation is the Guard: one Skill plus two Hook events. Install
-Skill only when you prefer advisory guidance without runtime enforcement.
-
-If a Codex agent is doing the installation for you, give it
+If an agent is doing the installation for you, give it
 [`INSTALL_FOR_AGENTS.md`](INSTALL_FOR_AGENTS.md). That guide separates commands
 the agent can run from the Hook review that you must complete yourself.
 
-## Default: Skill + Guard
+## Claude Code: Skill + Guard
+
+The Guard requires Node.js 18 or newer. From the parent directory of a local
+checkout, add the checkout as a local Claude marketplace, then install the
+plugin:
+
+```bash
+claude plugin validate ./stop-that-shit-claude-code
+claude plugin marketplace add ./stop-that-shit-claude-code
+claude plugin install stop-that-shit@stop-that-shit
+```
+
+Restart Claude Code after installation. The plugin registers four Hook events:
+
+- `SessionStart` — injects the current contract into a new session;
+- `UserPromptSubmit` — reads host-neutral `$stop-that-shit ...` directives,
+  natural explicit corrections, and the direct `/stop-that-shit:stop-that-shit
+  ...` slash form. Handling the slash form here keeps direct Skill invocation
+  armed even on hosts that do not expose the `UserPromptExpansion` event;
+- `PreToolUse` — classifies covered actions and can return permission deny;
+- `SubagentStart` — injects the current contract into a started subagent. Agent
+  budget enforcement happens earlier on `PreToolUse` for the `Agent` tool.
+
+Hosts that expose `UserPromptExpansion` may register it for earlier,
+pre-expansion arming; the adapter keeps that handler, but the packaged
+`hooks/hooks.json` stays limited to events every supported host accepts.
+
+## Codex: Skill + Guard
 
 The Guard requires Node.js 18 or newer. Add the repository as a Codex
 marketplace, then install the plugin:
@@ -22,12 +47,13 @@ codex plugin add stop-that-shit@stop-that-shit
 
 Restart Codex after installation.
 
-### Verify the source
+## Verify the source
 
 Inspect these executable surfaces before trusting them:
 
-- `hooks/hooks.json`
-- `hooks/stop-that-shit.cjs`
+- `hooks/hooks.json` and `hooks/stop-that-shit-claude.cjs` for Claude Code;
+- `hooks/codex-hooks.json` and `hooks/stop-that-shit.cjs` for Codex;
+- `src/adapters/`;
 - `src/`
 
 From a local checkout, run:
@@ -38,10 +64,10 @@ npm run eval
 npm run release:check
 ```
 
-### Review two Hooks
+## Review two Hooks
 
-Start a fresh Codex CLI TUI and enter `/hooks`. Inspect each Stop That Shit
-command and trust it only if it matches the source you reviewed.
+Codex records trust for the Hook definition hash, so inspect each Stop That Shit
+command before trusting it. Start a fresh Codex CLI TUI and enter `/hooks`.
 
 Only two events are required:
 
@@ -52,11 +78,37 @@ After review, both rows show `Installed 1 / Active 1 / Review 0`. `Stop 0` is
 expected; the plugin does not install a Stop handler.
 
 Some Codex Desktop builds send `/hooks` as an ordinary message. In that case,
-complete the review in the CLI TUI and restart Desktop. Codex records trust
-against the Hook definition hash, so an update may require another review. Do
+complete the review in the CLI TUI and restart Desktop. An update may require
+another review because Codex records trust against the Hook definition hash. Do
 not bypass Hook trust for ordinary installation.
 
-### Run a smoke test
+## Run a smoke test
+
+### Claude Code
+
+Use a disposable repository. First arm read-only review:
+
+```text
+/stop-that-shit:stop-that-shit review -- Review this repository. Report findings; do not edit.
+```
+
+A covered `Write`, `Edit`, `NotebookEdit`, `EnterWorktree`, mutating
+`Bash`/`PowerShell`/`Monitor` command, or unknown shell command must not run
+under the armed non-mutating contract. Then switch:
+
+```text
+/stop-that-shit:stop-that-shit change -- Create scratch/sts-smoke.txt containing the word pass.
+```
+
+That narrow write should proceed. For a file-lock test:
+
+```text
+/stop-that-shit:stop-that-shit lock change files=scratch/sts-smoke.txt -- Change only this file.
+```
+
+A covered write to a different path should be denied.
+
+### Codex
 
 In a disposable repository, start a review task:
 
@@ -79,16 +131,23 @@ sessions unless you pass `--run`.
 
 ## Optional: Skill only
 
-If you do not want command Hooks, ask the built-in Skill Installer to install
-only the shared Skill folder:
+If you do not want command Hooks, install only the advisory Skill. For Claude
+Code, copy the Skill into the user skills directory:
+
+```bash
+mkdir -p ~/.claude/skills/stop-that-shit
+cp skills/stop-that-shit/SKILL.md ~/.claude/skills/stop-that-shit/SKILL.md
+```
+
+For Codex, ask the built-in Skill Installer to install the shared Skill folder:
 
 ```text
 $skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.0.2/skills/stop-that-shit
 ```
 
-Start a new task so Codex discovers it. Skill only needs no Hook trust and has
-no runtime enforcement. It is advisory, model behavior can vary, and your
-existing Codex sandbox and approval settings still apply.
+Start a new task so the host discovers it. Skill only needs no Hook trust and
+has no runtime enforcement. It is advisory, model behavior can vary, and your
+existing sandbox and approval settings still apply.
 
 ## Local Guard development
 
@@ -102,9 +161,9 @@ codex plugin add stop-that-shit@stop-that-shit
 
 ## Disable or uninstall
 
-Use `/hooks` to disable the Guard immediately, then remove the plugin and
+Use `/hooks` to disable the Codex Guard immediately, then remove the plugin and
 marketplace when no longer needed. Skill only can be removed separately from
-the Codex Skills directory.
+the host Skills directory.
 
 ```powershell
 codex plugin remove stop-that-shit@stop-that-shit
@@ -122,5 +181,10 @@ If `CODEX_HOME` is unset, the default Skills directory is
 `$HOME\.codex\skills\stop-that-shit`. Check the resolved path before removing
 it.
 
-The Guard stores only the active per-session contract in the host-provided
-`PLUGIN_DATA` directory. Review that directory separately if you uninstall.
+Claude Code plugins are removed with the host's plugin controls. Claude Code
+cleans up `CLAUDE_PLUGIN_DATA` when the plugin is uninstalled from its last
+scope unless you uninstall with `--keep-data`.
+
+The Guard stores only the active per-session contract in the host-provided data
+directory (`PLUGIN_DATA` for Codex, `CLAUDE_PLUGIN_DATA` for Claude Code).
+Review that directory separately if you uninstall.

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -1,12 +1,43 @@
 # Install Stop That Shit as an Agent
 
-This file is for a Codex agent that is helping a user install Stop That Shit
-[`0.0.2`](https://github.com/lennney/stop-that-shit/releases/tag/0.0.2)
-Technical Preview 2. Keep the installation narrow. Do not clone the repository,
-modify the user's Codex configuration, copy authentication files, or bypass
-Hook review.
+This file is for an agent that is helping a user install Stop That Shit. Keep
+the installation narrow. Do not clone the repository, modify the user's host
+configuration, copy authentication files, or bypass Hook review.
 
-## Default installation
+## Claude Code
+
+1. Confirm that `claude` is available and Node.js 18 or newer is installed.
+2. From the parent directory of the local checkout, validate it:
+
+   ```bash
+   claude plugin validate ./stop-that-shit-claude-code
+   ```
+
+3. Add the local marketplace and install the plugin:
+
+   ```bash
+   claude plugin marketplace add ./stop-that-shit-claude-code
+   claude plugin install stop-that-shit@stop-that-shit
+   ```
+
+4. Ask the user to restart Claude Code or run `/reload-plugins`.
+5. In a disposable repository, verify that review stays read-only:
+
+   ```text
+   /stop-that-shit:stop-that-shit review -- Review this repository. Report findings; do not edit.
+   ```
+
+   Then give explicit change authority:
+
+   ```text
+   /stop-that-shit:stop-that-shit change -- Create scratch/sts-smoke.txt containing the word pass.
+   ```
+
+Report whether the review attempted a covered write and whether the change
+created only the requested file. Do not claim that one smoke test proves a
+general improvement in model behavior.
+
+## Codex
 
 1. Confirm that `codex` is available and Node.js 18 or newer is installed.
 2. Run these commands one at a time:
@@ -63,15 +94,3 @@ $skill-installer Install stop-that-shit from https://github.com/lennney/stop-tha
 Ask the user to start a new Codex task after installation. Explain that this
 mode has no runtime enforcement and cannot change Codex sandbox or approval
 settings.
-
-## Report back
-
-Tell the user:
-
-- which mode you installed;
-- the installed plugin version, if available;
-- whether the two expected Hook events are active;
-- the smoke-test result, if the user authorized one;
-- any step that still needs user action.
-
-For troubleshooting and uninstall commands, read [`INSTALL.md`](INSTALL.md).

--- a/README.md
+++ b/README.md
@@ -9,33 +9,35 @@
   <img src="https://img.shields.io/github/v/release/lennney/stop-that-shit?include_prereleases&sort=semver&style=flat-square&color=111111&label=release" alt="Latest release">
   <a href="https://github.com/lennney/stop-that-shit/actions/workflows/ci.yml"><img src="https://github.com/lennney/stop-that-shit/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
   <img src="https://img.shields.io/badge/works%20with-Codex-111111?style=flat-square" alt="Works with Codex">
+  <img src="https://img.shields.io/badge/works%20with-Claude%20Code-111111?style=flat-square" alt="Works with Claude Code">
   <img src="https://img.shields.io/github/license/lennney/stop-that-shit?style=flat-square&color=111111" alt="MIT license">
 </p>
 
 <p align="center">
-  <strong>You asked for one file. Codex split it into six modules, called in three agents, and added SHA-256 checksums. Stop That Shit.</strong><br>
-  Stop That Shit runs locally and blocks unneeded scope, subagents, dependencies, and hashes in Codex tasks.<br>
-  <a href="#install-in-two-commands">Install</a> ·
+  <strong>Keep the agent on the job you gave it.</strong><br>
+  <a href="#install">Install</a> ·
   <a href="#bad-case--good-case">Bad / Good Case</a> ·
   <a href="cases/README.md">Cases</a> ·
   <a href="CONTRIBUTING.md">Contribute</a> ·
   <a href="README_CN.md">中文</a>
 </p>
 
-Ask Codex for one small file and you may get a module tree, several subagents,
-a new dependency, and a SHA-256 checksum nobody uses.
+You give a coding agent a small task. It launches several subagents: one inspects the
+code, another reviews the result, and the main agent summarizes everything
+again. It generates a SHA-256 checksum without a consumer. You ask it to review
+a diff; after finding a bug, it starts editing.
 
 Every step comes with a careful explanation. The requested work is still not
-finished, and a noticeable part of the token budget went to work Codex invented
+finished, and a noticeable part of the token budget went to work the agent invented
 for itself.
 
 Adding “do not overengineer” to `AGENTS.md` helps until the file becomes a
 history of every behavior that annoyed you. Stop That Shit turns the small,
 high-confidence part of that history into a Skill and an executable Guard.
 
-Stop That Shit gives Codex a task boundary. The default Guard combines one
-small Skill with two Hook events. Codex still reads the repository and follows
-necessary consequences. When it crosses a boundary that the Guard can prove,
+Stop That Shit gives an agent a task boundary. The core Guard is
+shared; thin host adapters translate each host's Hook events. The agent still
+reads the repository and follows necessary consequences. When it crosses a boundary that the Guard can prove,
 it gets a red stamp:
 
 ```text
@@ -46,17 +48,33 @@ State: ARMED / review
 Event: evt_...
 ```
 
-Version [`0.0.2`](https://github.com/lennney/stop-that-shit/releases/tag/0.0.2)
-is Technical Preview 2. LLM runs vary, and Hooks see only part
-of a Codex run. The Skill and Guard can reduce some unwanted work. Neither can
-guarantee how the model will behave.
+LLM runs vary, and Hooks see only part of a host agent run. The Skill and Guard
+can reduce some unwanted work. Neither can guarantee how the model will behave.
 
 | Start with | What it adds | Friction |
 | --- | --- | --- |
-| **Skill + Guard** | Stop Ladder plus machine-enforced boundaries | Default; trust two Hooks |
+| **Skill + Guard** | Stop Ladder plus machine-enforced boundaries | Default; review the host Hook configuration |
 | **Skill only** | The Stop Ladder and task-mode guidance | Optional; no enforcement |
 
-## Install in two commands
+## Quick install
+
+### Claude Code
+
+Extract the repository, then from its parent directory:
+
+```bash
+claude plugin validate ./stop-that-shit-claude-code
+claude plugin marketplace add ./stop-that-shit-claude-code
+claude plugin install stop-that-shit@stop-that-shit
+```
+
+Restart Claude Code or run `/reload-plugins`, then invoke:
+
+```text
+/stop-that-shit:stop-that-shit review -- Review this diff. Report findings; do not edit.
+```
+
+### Codex
 
 ```bash
 codex plugin marketplace add lennney/stop-that-shit
@@ -132,13 +150,20 @@ ALLOW
 Use a digest to skip rereading an unchanged large file.
 ```
 
-`0.0.2` denies a recognized new hash operation by default. Use `hash=allow`
+The Guard denies a recognized new hash operation by default. Use `hash=allow`
 when the user or the repository supplies the missing job. The Hook does not try
 to infer that job from code it has not seen.
 
 ## Use it
 
-Most tasks need one line:
+Most tasks need one line. Claude Code plugin:
+
+```text
+/stop-that-shit:stop-that-shit change -- Fix the failing config test.
+/stop-that-shit:stop-that-shit review -- Review this diff. Report findings; do not edit.
+```
+
+Codex or host-neutral prompt directive:
 
 ```text
 $stop-that-shit change -- Fix the failing config test.
@@ -177,7 +202,7 @@ effect. Stop That Shit reports host effect as `unobserved`.
 
 ## What the Guard stops
 
-| Codex action on a covered path | Default | You can allow it with |
+| Covered host action | Default | You can allow it with |
 | --- | --- | --- |
 | Write during `review`, `answer`, or `monitor` | Stop | Switch to `change` |
 | Add a dependency | Ask | `deps=allow` |
@@ -195,17 +220,15 @@ questions:
 3. What reachable evidence shows that need?
 4. Would the current acceptance fail without it?
 
-Codex reports or defers the extra work when the answers do not support it.
+The agent reports or defers the extra work when the answers do not support it.
 
 ## How it works
 
-The Skill guides semantic choices. The Hook enforces explicit facts before a
-supported tool runs. A small host Adapter translates Codex events into the core
-decision interface.
-
-Codex is the only implemented Adapter in `0.0.2`. Another harness can use the
-same core when it provides an equivalent before-action event. See
-[HOST-ADAPTER-CONTRACT.md](HOST-ADAPTER-CONTRACT.md).
+The Skill guides semantic choices. Hooks enforce explicit facts before supported
+tools run. Small host Adapters translate each host's events into the same core
+decision interface. Each Adapter exposes the host events it needs, for example
+hard denial before tool use and lifecycle events that carry the active
+contract. See [HOST-ADAPTER-CONTRACT.md](HOST-ADAPTER-CONTRACT.md).
 
 ## Limits and evidence
 
@@ -218,11 +241,24 @@ tests, live runs, null results, and exclusions.
 
 ## Install
 
-### Default: install the Guard
+### Claude Code: Skill + Guard
 
-The Guard supports Codex desktop and CLI installations with Plugin and Hook
-support. It requires Node.js 18 or newer. Read the Hook source before trusting
-it, then install:
+Requires Node.js 18 or newer. From a local checkout:
+
+```bash
+claude plugin validate ./stop-that-shit-claude-code
+claude plugin marketplace add ./stop-that-shit-claude-code
+claude plugin install stop-that-shit@stop-that-shit
+```
+
+Restart or `/reload-plugins`. Claude loads `skills/`, `hooks/hooks.json`, and the
+Claude adapter. The Guard covers `Write`, `Edit`, `NotebookEdit`, `EnterWorktree`,
+shell/`Monitor` mutation, dependency/hash intent, optional file locks, and
+`Agent` budgets on supported Hook paths. Claude `Workflow` is conservatively
+denied while the Guard is armed because its internal subagent fan-out cannot be
+bounded by `agents=N`.
+
+### Codex: Skill + Guard
 
 ```bash
 codex plugin marketplace add lennney/stop-that-shit
@@ -237,14 +273,21 @@ message, use the CLI TUI for this review, then restart Desktop.
 
 ### Optional: Skill only
 
-If you do not want command Hooks, install only the advisory Skill:
+If you do not want command Hooks, install only the advisory Skill. For Claude Code:
+
+```bash
+mkdir -p ~/.claude/skills/stop-that-shit
+cp skills/stop-that-shit/SKILL.md ~/.claude/skills/stop-that-shit/SKILL.md
+```
+
+For Codex, the remote Skill Installer path is:
 
 ```text
 $skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.0.2/skills/stop-that-shit
 ```
 
-Start a new task, then invoke `$stop-that-shit`. This path needs no Hook trust,
-but it cannot enforce a task boundary or change your Codex sandbox and approval
+Start a new task, then invoke the host-native Skill form. A standalone Claude Code skill is `/stop-that-shit`; an installed plugin skill is namespaced as `/stop-that-shit:stop-that-shit`; Codex uses `$stop-that-shit`. This path needs no Hook trust,
+but it cannot enforce a task boundary or change the host sandbox and approval
 settings.
 
 See [INSTALL.md](INSTALL.md) for the complete Skill and Guard paths. Run the

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 </p>
 
 <p align="center">
-  <strong>Keep the agent on the job you gave it.</strong><br>
+  <strong>You asked for one file. Codex split it into six modules, called in three agents, and added SHA-256 checksums. Stop That Shit.</strong><br>
+  Stop That Shit runs locally through adapters for Codex, Claude Code, and OpenCode.<br>
   <a href="#install">Install</a> ·
   <a href="#bad-case--good-case">Bad / Good Case</a> ·
   <a href="cases/README.md">Cases</a> ·
@@ -22,23 +23,21 @@
   <a href="README_CN.md">中文</a>
 </p>
 
-You give a coding agent a small task. It launches several subagents: one inspects the
-code, another reviews the result, and the main agent summarizes everything
-again. It generates a SHA-256 checksum without a consumer. You ask it to review
-a diff; after finding a bug, it starts editing.
+Ask Codex for one small file and you may get a module tree, several subagents,
+a new dependency, and a SHA-256 checksum nobody uses.
 
 Every step comes with a careful explanation. The requested work is still not
-finished, and a noticeable part of the token budget went to work the agent invented
+finished, and a noticeable part of the token budget went to work Codex invented
 for itself.
 
 Adding “do not overengineer” to `AGENTS.md` helps until the file becomes a
 history of every behavior that annoyed you. Stop That Shit turns the small,
 high-confidence part of that history into a Skill and an executable Guard.
 
-Stop That Shit gives an agent a task boundary. The core Guard is
-shared; thin host adapters translate each host's Hook events. The agent still
-reads the repository and follows necessary consequences. When it crosses a boundary that the Guard can prove,
-it gets a red stamp:
+Stop That Shit gives Codex, Claude Code, and OpenCode a task boundary. They
+share one core Guard; thin adapters translate each host's events. Each agent
+still reads the repository and follows necessary consequences. When the Guard
+can prove that an action crossed the boundary, it returns a red stamp:
 
 ```text
 STOP / INTENT

--- a/README_CN.md
+++ b/README_CN.md
@@ -9,26 +9,26 @@
   <img src="https://img.shields.io/github/v/release/lennney/stop-that-shit?include_prereleases&sort=semver&style=flat-square&color=111111&label=release" alt="最新版本">
   <a href="https://github.com/lennney/stop-that-shit/actions/workflows/ci.yml"><img src="https://github.com/lennney/stop-that-shit/actions/workflows/ci.yml/badge.svg" alt="CI 状态"></a>
   <img src="https://img.shields.io/badge/works%20with-Codex-111111?style=flat-square" alt="支持 Codex">
+  <img src="https://img.shields.io/badge/works%20with-Claude%20Code-111111?style=flat-square" alt="支持 Claude Code">
   <img src="https://img.shields.io/github/license/lennney/stop-that-shit?style=flat-square&color=111111" alt="MIT 许可证">
 </p>
 
 <p align="center">
-  <strong>你只要一个文件，Codex 却拆成六个模块，叫来三个 Agent，又给所有东西算了一遍 SHA-256。Stop That Shit。</strong><br>
-  Stop That Shit 在本地检查 Codex 的动作，拦住它擅自扩任务、叫 subagent、加依赖或算哈希。<br>
-  <a href="#两条命令安装">安装</a> ·
+  <strong>别再造史了：让 agent 只做你交代的活。</strong><br>
+  <a href="#安装">安装</a> ·
   <a href="#bad-case--good-case">Bad / Good Case</a> ·
   <a href="cases/README.md">案例库</a> ·
   <a href="CONTRIBUTING.md">参与贡献</a> ·
   <a href="README.md">English</a>
 </p>
 
-让 Codex 写个小文件，结果可能多出一棵模块树、几个 subagent、一项新依赖，还有一份没人会用的 SHA-256 checksum。
+你给 coding agent 一个很小的任务，它动不动就拉起几个 subagent：这个查一遍，那个再 review 一遍，回来以后主 agent 还要重新总结一遍。它也很爱先生成一份 SHA-256 checksum，至于后面谁会用，不知道，反正先算了再说。你让它 review 一个 diff，它发现问题以后直接开始改代码。
 
-每一步都能说出一个挺严谨的理由。回头一看，要的东西还没做完，token 已经花了一截。花在正事上没意见，花在 Codex 自己加出来的活上，就很心疼。
+每一步都能说出一个挺严谨的理由。回头一看，要的东西还没做完，token 已经花了一截。花在正事上没意见，花在 agent 自己加出来的活上，就很心疼。
 
 我也试过在 `AGENTS.md` 里不断补规则：「不要乱改」「别过度设计」「没让我做的先别做」。每被气到一次就补一条，写着写着，`AGENTS.md` 自己也开始造史了。Stop That Shit 把其中少量、能明确判断的边界做成 Skill 和可执行的 Guard。
 
-Stop That Shit 为 Codex 划定任务边界。默认的 Guard 由一个小 Skill 和两个 Hook 事件组成。Codex 仍然可以读仓库，也必须处理真正受影响的调用方。它碰到 Guard 能确认的越界动作时，会收到一枚红章：
+Stop That Shit 为 agent 划定任务边界。核心 Guard 与 Skill 共用，宿主差异只放在薄 Adapter 和 Hook 配置中。agent 仍然可以读仓库，也必须处理真正受影响的调用方。它碰到 Guard 能确认的越界动作时，会收到一枚红章：
 
 ```text
 STOP / INTENT
@@ -38,14 +38,32 @@ State: ARMED / review
 Event: evt_...
 ```
 
-[`0.0.2`](https://github.com/lennney/stop-that-shit/releases/tag/0.0.2) 是第二个技术预览版。LLM 每次运行都可能不同，Hook 也看不到 Codex 的全部动作。Skill 和 Guard 可以减少一部分越界行为，但都不能保证模型每次听话。
+LLM 每次运行都可能不同，Hook 也看不到宿主 agent 的全部动作。Skill 和 Guard 可以减少一部分越界行为，但都不能保证模型每次听话。
 
 | 从哪里开始 | 提供什么 | 使用成本 |
 | --- | --- | --- |
-| **Skill + Guard** | 同一份 Skill，加上机器可执行边界 | 默认；检查并信任两个 Hook |
+| **Skill + Guard** | 同一份 Skill，加上机器可执行边界 | 默认；检查宿主 Hook 配置后启用 |
 | **只装 Skill** | Stop Ladder 和任务模式引导 | 可选；没有执行拦截 |
 
-## 两条命令安装
+## 快速安装
+
+### Claude Code
+
+解压后，在仓库父目录执行：
+
+```bash
+claude plugin validate ./stop-that-shit-claude-code
+claude plugin marketplace add ./stop-that-shit-claude-code
+claude plugin install stop-that-shit@stop-that-shit
+```
+
+重启 Claude Code 或执行 `/reload-plugins`，然后使用：
+
+```text
+/stop-that-shit:stop-that-shit review -- Review 这个 diff，只报告问题，不要修改。
+```
+
+### Codex
 
 ```bash
 codex plugin marketplace add lennney/stop-that-shit
@@ -107,11 +125,18 @@ ALLOW
 用 digest 跳过一个未变化大文件的重复读取。
 ```
 
-`0.0.2` 默认拒绝可识别的新 hash 操作。用户明确要求，或仓库中的代码与发布流程证明它确实必要时，就用 `hash=allow` 放行。Hook 不会根据自己没读过的代码猜测这个用途。
+Guard 默认拒绝可识别的新 hash 操作。用户明确要求，或仓库中的代码与发布流程证明它确实必要时，就用 `hash=allow` 放行。Hook 不会根据自己没读过的代码猜测这个用途。
 
 ## 怎么用
 
-普通任务只要一行：
+Claude Code 插件直接用 namespaced Skill：
+
+```text
+/stop-that-shit:stop-that-shit change -- 修复失败的配置测试。
+/stop-that-shit:stop-that-shit review -- Review 这个 diff，只报告问题，不要修改。
+```
+
+Codex 或普通 prompt 里的宿主无关指令仍然使用：
 
 ```text
 $stop-that-shit change -- 修复失败的配置测试。
@@ -127,7 +152,7 @@ $stop-that-shit change hash=allow -- 生成我要求的发布校验和。
 $stop-that-shit change agents=1 -- 使用一个独立测试 subagent。
 ```
 
-不知道全部受影响文件时，不要硬写 `files=`。让 Codex 沿真实调用链检查，把完成任务必需的 caller、fixture 和测试一起改完。
+不知道全部受影响文件时，不要硬写 `files=`。让 agent 沿真实调用链检查，把完成任务必需的 caller、fixture 和测试一起改完。
 
 安装后默认是 `OBSERVING / unconfirmed`：Guard 会检查并记录 covered action，但不会猜测任务授权，也不会返回 permission deny。显式使用 `review`、`answer`、`monitor` 或 `change` 后才进入 `ARMED`；`watch` 始终只观察。
 
@@ -159,13 +184,11 @@ Hook 必须收到受支持的事件和足够的输入才能判断。它不会看
 3. 哪段可达的代码、数据或部署状态证明它有必要？
 4. 省掉它，当前验收会失败吗？
 
-证据撑不住时，Codex 应该报告或暂缓，不要顺手实现。
+证据撑不住时，agent 应该报告或暂缓，不要顺手实现。
 
 ## 工作方式
 
-Skill 负责语义判断。Hook 在受支持的工具运行前检查明确事实。Codex Adapter 把宿主事件翻译成核心决策接口。
-
-`0.0.2` 只实现了 Codex Adapter。其他 harness 需要提供等价的 before-action 事件，才能复用同一套核心。接口说明见 [HOST-ADAPTER-CONTRACT.md](HOST-ADAPTER-CONTRACT.md)。
+Skill 负责语义判断。Hook 在受支持的工具运行前检查明确事实。每个宿主只有一层薄 Adapter，把宿主事件翻译成同一套核心决策接口。各 Adapter 暴露自己需要的宿主事件，比如工具运行前的硬阻断，以及携带活动合同的生命周期事件。接口说明见 [HOST-ADAPTER-CONTRACT.md](HOST-ADAPTER-CONTRACT.md)。
 
 ## 局限和证据
 
@@ -175,28 +198,47 @@ Skill 负责语义判断。Hook 在受支持的工具运行前检查明确事实
 
 ## 安装
 
-### 默认安装：Guard
+### Claude Code：Skill + Guard
 
-Guard 面向支持 Plugin 和 Hook 的 Codex desktop 与 CLI，需要 Node.js 18 或更高版本。
+需要 Node.js 18+。从本地 checkout 安装：
 
-信任 Hook 前先读源码，然后安装插件：
+```bash
+claude plugin validate ./stop-that-shit-claude-code
+claude plugin marketplace add ./stop-that-shit-claude-code
+claude plugin install stop-that-shit@stop-that-shit
+```
+
+重启或执行 `/reload-plugins`。Claude 会加载共享 `skills/`、`hooks/hooks.json`
+以及 Claude Adapter。Guard 覆盖 `Write`、`Edit`、`NotebookEdit`、`EnterWorktree`、
+shell/`Monitor` mutation、dependency/hash intent、可选 file lock，以及受支持路径上的
+`Agent` budget。Claude `Workflow` 在 Guard 武装时会保守拒绝，因为它内部的 subagent
+fan-out 无法被 `agents=N` 确定性约束。
+
+### Codex：Skill + Guard
 
 ```bash
 codex plugin marketplace add lennney/stop-that-shit
 codex plugin add stop-that-shit@stop-that-shit
 ```
 
-重启 Codex。新开一个 Codex CLI TUI，输入 `/hooks`，检查 Stop That Shit 的两个 Hook。完成信任后，`UserPromptSubmit` 和 `PreToolUse` 应显示 `Active 1 / Review 0`。`Stop 0` 是正常结果，因为插件没有注册 Stop Hook。如果 Desktop 把 `/hooks` 当成普通消息，请在 CLI TUI 中完成检查和信任，再重启 Desktop。
+重启 Codex。在新的 CLI TUI 中输入 `/hooks`，检查命令后信任 `UserPromptSubmit` 和 `PreToolUse`。如果 Codex Desktop 把 `/hooks` 当成普通消息发送，就在 CLI TUI 里完成这次审查，再重启 Desktop。
 
 ### 可选安装：只装 Skill
 
-不想启用命令 Hook 时，让 Codex 内置的 Skill Installer 只安装 Skill：
+如果不想启用命令 Hook，只安装 advisory Skill。Claude Code：
+
+```bash
+mkdir -p ~/.claude/skills/stop-that-shit
+cp skills/stop-that-shit/SKILL.md ~/.claude/skills/stop-that-shit/SKILL.md
+```
+
+Codex 仍可使用远程 Skill Installer：
 
 ```text
 $skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.0.2/skills/stop-that-shit
 ```
 
-新开任务后调用 `$stop-that-shit`。这条路径不需要 Hook 信任，但不能机器拦截越界动作，也不会改变 Codex 原有的 sandbox 和 approval 设置。
+新开任务后，独立 Claude Code Skill 用 `/stop-that-shit`，作为 plugin 安装时用 namespaced `/stop-that-shit:stop-that-shit`；Codex 用 `$stop-that-shit`。Skill-only 路径不需要 Hook 信任，但不能机器拦截越界动作，也不会改变宿主原有的 sandbox 和 approval 设置。
 
 完整的 Skill 与 Guard 安装说明见 [INSTALL.md](INSTALL.md)。然后运行本地检查：
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -14,7 +14,8 @@
 </p>
 
 <p align="center">
-  <strong>别再造史了：让 agent 只做你交代的活。</strong><br>
+  <strong>你只要一个文件，Codex 却拆成六个模块，叫来三个 Agent，又给所有东西算了一遍 SHA-256。Stop That Shit。</strong><br>
+  Stop That Shit 通过本地 Adapter 支持 Codex、Claude Code 和 OpenCode。<br>
   <a href="#安装">安装</a> ·
   <a href="#bad-case--good-case">Bad / Good Case</a> ·
   <a href="cases/README.md">案例库</a> ·
@@ -22,13 +23,15 @@
   <a href="README.md">English</a>
 </p>
 
-你给 coding agent 一个很小的任务，它动不动就拉起几个 subagent：这个查一遍，那个再 review 一遍，回来以后主 agent 还要重新总结一遍。它也很爱先生成一份 SHA-256 checksum，至于后面谁会用，不知道，反正先算了再说。你让它 review 一个 diff，它发现问题以后直接开始改代码。
+让 Codex 写个小文件，结果可能多出一棵模块树、几个 subagent、一项新依赖，还有一份没人会用的 SHA-256 checksum。
 
-每一步都能说出一个挺严谨的理由。回头一看，要的东西还没做完，token 已经花了一截。花在正事上没意见，花在 agent 自己加出来的活上，就很心疼。
+每一步都能说出一个挺严谨的理由。回头一看，要的东西还没做完，token 已经花了一截。花在正事上没意见，花在 Codex 自己加出来的活上，就很心疼。
 
 我也试过在 `AGENTS.md` 里不断补规则：「不要乱改」「别过度设计」「没让我做的先别做」。每被气到一次就补一条，写着写着，`AGENTS.md` 自己也开始造史了。Stop That Shit 把其中少量、能明确判断的边界做成 Skill 和可执行的 Guard。
 
-Stop That Shit 为 agent 划定任务边界。核心 Guard 与 Skill 共用，宿主差异只放在薄 Adapter 和 Hook 配置中。agent 仍然可以读仓库，也必须处理真正受影响的调用方。它碰到 Guard 能确认的越界动作时，会收到一枚红章：
+Stop That Shit 为 Codex、Claude Code 和 OpenCode 划定任务边界。三者共用核心
+Guard，宿主差异只放在薄 Adapter 和 Hook 配置中。Agent 仍然可以读仓库，也必须
+处理真正受影响的调用方。Guard 确认某个动作越界时，会返回一枚红章：
 
 ```text
 STOP / INTENT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,13 @@
 # Security
 
 Stop That Shit is an execution guardrail, not a security sandbox or permission
-boundary. It can deny only lifecycle events that the active Codex surface sends
+boundary. It can deny only lifecycle events that the active host surface sends
 through covered and trusted Hooks. Specialized tool paths, disabled Hooks,
 untrusted Hook definitions, host bugs, or direct user actions may bypass it.
 
 ## Supported version
 
-`0.0.2` is a pre-release. Security and compatibility support are best effort
+`0.0.3` is a pre-release. Security and compatibility support are best effort
 until the first stable release.
 
 ## Reporting a vulnerability
@@ -17,7 +17,7 @@ Before public release, the repository owner must enable GitHub private
 vulnerability reporting. Until a private channel exists, submit only a
 sanitized issue that asks the maintainer to establish private contact.
 
-Useful reports identify the affected revision, Codex surface and version, Hook
+Useful reports identify the affected revision, host surface and version, Hook
 trust state, minimal reproduction, expected boundary, and observed result.
 
 ## Maintainer release requirements

--- a/hooks/codex-hooks.json
+++ b/hooks/codex-hooks.json
@@ -1,0 +1,29 @@
+{
+  "description": "Stop That Shit: a small on-demand policy with a few high-confidence Codex gates.",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const p=require('node:path');require(p.join(process.env.PLUGIN_ROOT??process.env.CLAUDE_PLUGIN_ROOT,'hooks','stop-that-shit.cjs'))\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const p=require('node:path');require(p.join(process.env.PLUGIN_ROOT??process.env.CLAUDE_PLUGIN_ROOT,'hooks','stop-that-shit.cjs'))\"",
+            "timeout": 5,
+            "statusMessage": "Checking the Stop Ladder..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,12 +1,24 @@
 {
-  "description": "Stop That Shit: a small on-demand policy with a few high-confidence Codex gates.",
+  "description": "Stop That Shit for Claude Code: local-first execution control for mode, scope, dependencies, hashing, and delegation.",
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-that-shit-claude.cjs\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const p=require('node:path');require(p.join(process.env.PLUGIN_ROOT??process.env.CLAUDE_PLUGIN_ROOT,'hooks','stop-that-shit.cjs'))\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-that-shit-claude.cjs\"",
             "timeout": 5
           }
         ]
@@ -18,9 +30,21 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const p=require('node:path');require(p.join(process.env.PLUGIN_ROOT??process.env.CLAUDE_PLUGIN_ROOT,'hooks','stop-that-shit.cjs'))\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-that-shit-claude.cjs\"",
             "timeout": 5,
             "statusMessage": "Checking the Stop Ladder..."
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-that-shit-claude.cjs\"",
+            "timeout": 5
           }
         ]
       }

--- a/hooks/stop-that-shit-claude.cjs
+++ b/hooks/stop-that-shit-claude.cjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const { handleClaudeHook } = require('../src/adapters/claude-hooks.cjs');
+
+function readStdin(maxWaitMs = 1500) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let body = '';
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(body);
+    };
+
+    const timer = setTimeout(finish, maxWaitMs);
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      body += chunk;
+    });
+    process.stdin.on('end', finish);
+    process.stdin.on('error', finish);
+    process.stdin.resume();
+  });
+}
+
+(async () => {
+  try {
+    const raw = await readStdin();
+    if (!raw.trim()) return;
+
+    const input = JSON.parse(raw);
+    const output = handleClaudeHook(input);
+    if (output) {
+      process.stdout.write(`${JSON.stringify(output)}\n`);
+    }
+  } catch (error) {
+    const errorName = error && error.name ? error.name : 'HookError';
+    process.stderr.write(`Stop That Shit Claude hook failed open: ${errorName}\n`);
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stop-that-shit",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stop-that-shit",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "devDependencies": {
         "ajv": "^8.20.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stop-that-shit",
   "version": "0.0.3",
   "private": true,
-  "description": "Local-first execution control for coding agents",
+  "description": "Stop unneeded scope, subagents, dependencies, and hashes in Codex, Claude Code, and OpenCode tasks",
   "license": "MIT",
   "main": "./opencode/stop-that-shit.mjs",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "stop-that-shit",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
-  "description": "Stop unneeded scope, subagents, dependencies, and hashes in Codex tasks",
+  "description": "Local-first execution control for coding agents",
   "license": "MIT",
   "scripts": {
     "schema:build": "node scripts/build-case-bundle-validator.cjs",
     "schema:check": "node scripts/build-case-bundle-validator.cjs --check",
     "pretest": "npm run schema:check",
-    "test": "node --test test/case-bundle.test.cjs test/contracts.test.cjs test/control-protocol.test.cjs test/decision.test.cjs test/hooks.test.cjs test/paired-eval.test.cjs test/plugin.test.cjs test/runtime-audit.test.cjs test/sts-cli.test.cjs",
+    "test": "node --test test/case-bundle.test.cjs test/claude-adapter.test.cjs test/claude-plugin.test.cjs test/contracts.test.cjs test/control-protocol.test.cjs test/decision.test.cjs test/hooks.test.cjs test/paired-eval.test.cjs test/plugin.test.cjs test/runtime-audit.test.cjs test/sts-cli.test.cjs",
     "sts": "node scripts/sts.cjs",
     "eval": "node scripts/evaluate-cases.cjs",
     "eval:paired": "node scripts/run-paired-eval.cjs",

--- a/release-files.json
+++ b/release-files.json
@@ -2,6 +2,7 @@
   "version": 1,
   "include": [
     ".agents",
+    ".claude-plugin",
     ".codex-plugin",
     ".github",
     ".gitignore",

--- a/scripts/release-check.cjs
+++ b/scripts/release-check.cjs
@@ -44,12 +44,21 @@ for (const entry of releaseManifest.include) {
 }
 
 const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
-const pluginJson = JSON.parse(fs.readFileSync(path.join(root, '.codex-plugin', 'plugin.json'), 'utf8'));
+const codexPlugin = JSON.parse(fs.readFileSync(path.join(root, '.codex-plugin', 'plugin.json'), 'utf8'));
+const claudePlugin = JSON.parse(fs.readFileSync(path.join(root, '.claude-plugin', 'plugin.json'), 'utf8'));
+const claudeMarketplace = JSON.parse(fs.readFileSync(path.join(root, '.claude-plugin', 'marketplace.json'), 'utf8'));
 const expectedVersion = packageJson.version;
 if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(expectedVersion)) {
   fail(`package version is not semver: ${expectedVersion}`);
 }
-if (packageJson.version !== pluginJson.version) fail('package and plugin versions differ');
+if (expectedVersion !== codexPlugin.version) fail('package and Codex plugin versions differ');
+if (expectedVersion !== claudePlugin.version) fail('package and Claude plugin versions differ');
+if (!claudeMarketplace.plugins || claudeMarketplace.plugins[0]?.name !== claudePlugin.name || claudeMarketplace.plugins[0]?.source !== './') {
+  fail('Claude marketplace does not point at the root plugin');
+}
+if (Object.hasOwn(claudeMarketplace.plugins?.[0] || {}, 'version')) {
+  fail('Claude marketplace duplicates the plugin version; keep version in plugin.json only');
+}
 
 const selectedFiles = releaseManifest.include.flatMap((entry) => walk(path.join(root, entry)));
 const textExtensions = new Set(['', '.cjs', '.js', '.json', '.md', '.txt', '.yaml', '.yml']);
@@ -66,12 +75,23 @@ for (const file of selectedFiles) {
   if (mojibake.test(content)) fail(`possible mojibake in ${relative}`);
 }
 
-const hooks = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'hooks.json'), 'utf8'));
-for (const groups of Object.values(hooks.hooks)) {
+const codexHooks = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'codex-hooks.json'), 'utf8'));
+for (const groups of Object.values(codexHooks.hooks)) {
   for (const group of groups) {
     for (const hook of group.hooks) {
       if (!hook.command.includes('process.env.PLUGIN_ROOT')) {
-        fail('a Hook command does not resolve from PLUGIN_ROOT');
+        fail('a Codex Hook command does not resolve from PLUGIN_ROOT');
+      }
+    }
+  }
+}
+const claudeHooks = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'hooks.json'), 'utf8'));
+for (const groups of Object.values(claudeHooks.hooks)) {
+  for (const group of groups) {
+    for (const hook of group.hooks) {
+      if (hook.type !== 'command') fail('a Claude Hook is not a command hook');
+      if (hook.command !== 'node "${CLAUDE_PLUGIN_ROOT}/hooks/stop-that-shit-claude.cjs"') {
+        fail('a Claude Hook does not resolve its entrypoint from CLAUDE_PLUGIN_ROOT as a shell-form command');
       }
     }
   }
@@ -81,5 +101,5 @@ if (failures.length) {
   for (const failure of failures) process.stderr.write(`FAIL ${failure}\n`);
   process.exitCode = 1;
 } else {
-  process.stdout.write(`PASS release allowlist (${selectedFiles.length} files, version ${expectedVersion})\n`);
+  process.stdout.write(`PASS release allowlist (${selectedFiles.length} files, version ${expectedVersion}, dual-host)\n`);
 }

--- a/skills/stop-that-shit/SKILL.md
+++ b/skills/stop-that-shit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stop-that-shit
-description: Keep Codex focused on requested and necessary work. Use for bounded changes, review-only tasks, scope creep, speculative hardening, unnecessary hashing or dependencies, repeated audit loops, or when the user invokes Stop That Shit.
+description: Keep an agent focused on requested and necessary work. Use for bounded changes, review-only tasks, scope creep, speculative hardening, unnecessary hashing or dependencies, repeated audit loops, or when the user invokes Stop That Shit.
 ---
 
 # Stop That Shit
@@ -9,7 +9,7 @@ Do the requested work. Keep necessary consequences. Stop everything else.
 
 This Skill is advisory and works without the Guard hooks. It cannot guarantee
 model behavior. When the Guard is installed, the same directives also provide
-machine-enforced boundaries on supported Codex Hook paths.
+machine-enforced boundaries on supported host Hook paths.
 
 ## Follow the Stop Ladder
 
@@ -36,7 +36,17 @@ is not the goal. The smallest correct result is.
 - Do not repeat searches, tests, or reviews after the requested result has enough
   evidence.
 
-With Skill only, treat the mode as an instruction. With Guard installed, use:
+With Skill only, treat the mode as an instruction. With the Guard installed,
+use the host-native invocation form.
+
+Claude Code plugin:
+
+```text
+/stop-that-shit:stop-that-shit change -- Fix the failing config test.
+/stop-that-shit:stop-that-shit review -- Review this diff. Report findings; do not edit.
+```
+
+Codex plugin or host-neutral directive inside a prompt:
 
 ```text
 $stop-that-shit change -- Fix the failing config test.
@@ -47,7 +57,9 @@ An installed Guard begins in observation-only `unconfirmed` mode. Do not claim
 that an action was blocked unless an explicit mode armed the Guard and the Guard
 returned permission deny. Even then, describe the host effect as unobserved.
 
-The following inspection commands do not change the current task contract:
+The following inspection commands do not change the current task contract. In
+Claude Code, pass the text after the namespaced slash command; in Codex, use the
+`$stop-that-shit` form shown below.
 
 ```text
 $stop-that-shit status
@@ -60,6 +72,12 @@ Use a hard file lock only when the complete boundary is already known:
 
 ```text
 $stop-that-shit lock change files=src/config.cjs|test/config.test.cjs -- Fix this behavior.
+```
+
+Claude Code equivalent:
+
+```text
+/stop-that-shit:stop-that-shit lock change files=src/config.cjs|test/config.test.cjs -- Fix this behavior.
 ```
 
 Do not invent a file list to appear precise. Inspect proportionately and explain

--- a/src/adapters/claude-hooks.cjs
+++ b/src/adapters/claude-hooks.cjs
@@ -1,0 +1,129 @@
+'use strict';
+
+const { PROTOCOL_VERSION } = require('../control-protocol.cjs');
+const { handleControlEvent } = require('../controller.cjs');
+const {
+  classifyClaudeTool,
+  detectDependencyIntent,
+  detectHashIntent,
+  extractAffectedPaths,
+  isUnboundedDelegation
+} = require('./claude-tool-classifier.cjs');
+
+const EVENT_KIND = {
+  SessionStart: 'session.start',
+  UserPromptSubmit: 'prompt.submit',
+  UserPromptExpansion: 'prompt.submit',
+  PreToolUse: 'action.before',
+  SubagentStart: 'subagent.start'
+};
+
+function isStopThatShitExpansion(input) {
+  if (!input || input.hook_event_name !== 'UserPromptExpansion') return false;
+  if (input.expansion_type && input.expansion_type !== 'slash_command') return false;
+  const name = String(input.command_name || '');
+  return /^(?:stop-that-shit:)?stop-that-shit$/i.test(name);
+}
+
+function expansionDirective(input) {
+  const args = String(input.command_args || '').trim();
+  return `$stop-that-shit${args ? ` ${args}` : ''}`;
+}
+
+function slashDirective(prompt) {
+  const text = String(prompt || '').trim();
+  const match = /^\/(?:stop-that-shit:)?stop-that-shit(?:\s+([\s\S]*))?$/i.exec(text);
+  if (!match) return null;
+  const args = (match[1] || '').trim();
+  return `$stop-that-shit${args ? ` ${args}` : ''}`;
+}
+
+function toControlEvent(input) {
+  if (!input || typeof input !== 'object') return null;
+  const kind = EVENT_KIND[input.hook_event_name];
+  if (!kind) return null;
+  if (input.hook_event_name === 'UserPromptExpansion' && !isStopThatShitExpansion(input)) return null;
+
+  const event = {
+    protocolVersion: PROTOCOL_VERSION,
+    kind,
+    sessionId: String(input.session_id || ''),
+    turnId: input.prompt_id || input.turn_id || null,
+    host: {
+      family: 'claude-code',
+      model: input.model || null,
+      permissionMode: input.permission_mode || null,
+      agentId: input.agent_id || null,
+      agentType: input.agent_type || null
+    }
+  };
+
+  if (kind === 'prompt.submit') {
+    event.prompt = input.hook_event_name === 'UserPromptExpansion'
+      ? expansionDirective(input)
+      // Hosts without the UserPromptExpansion event still route a direct
+      // /stop-that-shit... invocation through UserPromptSubmit; treat the
+      // slash form as the same directive so the Guard arms before tool use.
+      : slashDirective(input.prompt) || String(input.prompt || '');
+  }
+
+  if (kind === 'action.before') {
+    event.action = {
+      id: input.tool_use_id || null,
+      name: String(input.tool_name || 'unknown'),
+      input: input.tool_input,
+      mutability: classifyClaudeTool(input.tool_name, input.tool_input),
+      hashIntent: detectHashIntent(input.tool_name, input.tool_input),
+      dependencyIntent: detectDependencyIntent(input.tool_name, input.tool_input, input.cwd),
+      affectedPaths: extractAffectedPaths(input.tool_name, input.tool_input, input.cwd),
+      unboundedDelegation: isUnboundedDelegation(input.tool_name)
+    };
+  }
+
+  return event;
+}
+
+function contextOutput(hookEventName, text) {
+  return {
+    hookSpecificOutput: {
+      hookEventName,
+      additionalContext: text
+    }
+  };
+}
+
+function fromControlResult(hookEventName, result) {
+  if (!result || result.kind === 'none') return null;
+
+  if (result.kind === 'context') {
+    return contextOutput(hookEventName, result.text);
+  }
+
+  if (result.kind === 'deny') {
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: result.message
+      }
+    };
+  }
+
+  return null;
+}
+
+function handleClaudeHook(input, options = {}) {
+  const event = toControlEvent(input);
+  if (!event) return null;
+  const result = handleControlEvent(event, options);
+  return fromControlResult(input.hook_event_name, result);
+}
+
+module.exports = {
+  expansionDirective,
+  fromControlResult,
+  handleClaudeHook,
+  isStopThatShitExpansion,
+  slashDirective,
+  toControlEvent
+};

--- a/src/adapters/claude-tool-classifier.cjs
+++ b/src/adapters/claude-tool-classifier.cjs
@@ -1,0 +1,164 @@
+'use strict';
+
+const nodePath = require('node:path');
+const {
+  classifyCodexTool,
+  classifyShell,
+  detectDependencyIntent: detectCodexDependencyIntent,
+  detectHashIntent: detectCodexHashIntent
+} = require('./codex-tool-classifier.cjs');
+
+const CLAUDE_READ_TOOLS = new Set([
+  'Read',
+  'Glob',
+  'Grep',
+  'ListAgents',
+  'ListMcpResourcesTool',
+  'LSP',
+  'ReadMcpResourceTool',
+  'WebFetch',
+  'WebSearch'
+]);
+
+const CLAUDE_CONTROL_TOOLS = new Set([
+  'AskUserQuestion',
+  'CronCreate',
+  'CronDelete',
+  'CronList',
+  'EndConversation',
+  'EnterPlanMode',
+  'ExitPlanMode',
+  'ExitWorktree',
+  'PushNotification',
+  'ReportFindings',
+  'ScheduleWakeup',
+  'SendMessage',
+  'Skill',
+  'TodoWrite',
+  'TaskCreate',
+  'TaskUpdate',
+  'TaskList',
+  'TaskGet',
+  'TaskOutput',
+  'TaskStop',
+  'ToolSearch',
+  'WaitForMcpServers'
+]);
+
+const MANIFEST_PATH = /(?:^|\/)(?:package\.json|pyproject\.toml|requirements[^/]*\.txt|Cargo\.toml|go\.mod|composer\.json|Gemfile)$/i;
+const DEPENDENCY_DECLARATION = /["']?(?:dependencies|devDependencies|optionalDependencies|peerDependencies)["']?\s*[:=]|(?:^|\n)\s*[^#\s][^\r\n]*(?:==|>=|~=|\^\d)/i;
+const HASH_API = /\b(?:createHash|createHmac)\s*\(|\bcrypto\.subtle\.digest\s*\(|\bhashlib\.(?:md5|sha1|sha224|sha256|sha384|sha512|blake2[bs])\s*\(|\bMessageDigest\.getInstance\s*\(|\bDigestUtils\.[A-Za-z0-9_]+\s*\(|\bsha(?:1|256|512)\.(?:New|Sum\w*)\s*\(|\b(?:bcrypt|argon2)\.hash\s*\(|\bpassword_hash\s*\(|\bPasswordHasher\s*\(/i;
+
+function isWindowsAbsolute(value) {
+  return /^[A-Za-z]:[\\/]/.test(String(value || '')) || /^\\\\[^\\]+\\[^\\]+/.test(String(value || ''));
+}
+
+function normalizePath(value, cwd) {
+  const raw = String(value || '').trim().replace(/^['"]|['"]$/g, '');
+  if (!raw) return '';
+
+  const windowsStyle = isWindowsAbsolute(raw) || isWindowsAbsolute(cwd);
+  const pathApi = windowsStyle ? nodePath.win32 : nodePath;
+  let normalized = raw.replace(/\\/g, '/');
+  const normalizedCwd = String(cwd || '').replace(/\\/g, '/');
+
+  if (cwd && (pathApi.isAbsolute(raw) || isWindowsAbsolute(raw))) {
+    try {
+      normalized = pathApi.relative(String(cwd), raw).replace(/\\/g, '/');
+    } catch {
+      normalized = raw.replace(/\\/g, '/');
+    }
+  } else if (normalizedCwd && normalized.startsWith(`${normalizedCwd.replace(/\/+$/, '')}/`)) {
+    normalized = normalized.slice(normalizedCwd.replace(/\/+$/, '').length + 1);
+  }
+
+  return normalized.replace(/^\.\//, '');
+}
+
+function inputText(toolInput) {
+  if (typeof toolInput === 'string') return toolInput;
+  if (!toolInput || typeof toolInput !== 'object') return '';
+  return String(
+    toolInput.command
+      || toolInput.patch
+      || toolInput.content
+      || toolInput.new_string
+      || toolInput.new_source
+      || ''
+  );
+}
+
+function classifyClaudeTool(toolName, toolInput) {
+  const name = String(toolName || '');
+
+  if (name === 'Write' || name === 'Edit' || name === 'NotebookEdit' || name === 'EnterWorktree') return 'write';
+  if (name === 'Bash' || name === 'PowerShell' || name === 'Monitor') {
+    if (name === 'Monitor' && toolInput && toolInput.ws && !toolInput.command) return 'read';
+    return classifyShell(toolInput && toolInput.command);
+  }
+  if (name === 'Agent' || name === 'Workflow') return 'delegate';
+  if (CLAUDE_READ_TOOLS.has(name)) return 'read';
+  if (CLAUDE_CONTROL_TOOLS.has(name)) return 'control';
+
+  // MCP/plugin tools use names such as mcp__server__create_item. The existing
+  // name-based fallback is host-neutral for these separator-delimited names.
+  return classifyCodexTool(name, toolInput);
+}
+
+function extractAffectedPaths(toolName, toolInput, cwd) {
+  const name = String(toolName || '');
+  let value = '';
+
+  if (name === 'Write' || name === 'Edit') {
+    value = toolInput && (toolInput.file_path || toolInput.path);
+  } else if (name === 'NotebookEdit') {
+    value = toolInput && toolInput.notebook_path;
+  } else if (toolInput && typeof toolInput === 'object' && classifyCodexTool(name, toolInput) === 'write') {
+    // For third-party/MCP mutating tools, only trust an explicit single path
+    // field. Read-only tools do not participate in the write boundary. If a
+    // mutating tool has no provable path, the controller's file lock fails closed.
+    value = toolInput.file_path || toolInput.path || '';
+  }
+
+  const normalized = normalizePath(value, cwd);
+  return normalized ? [normalized] : [];
+}
+
+function detectHashIntent(toolName, toolInput) {
+  const name = String(toolName || '');
+  if (name === 'PowerShell' || name === 'Monitor') {
+    return detectCodexHashIntent('Bash', toolInput);
+  }
+  if (name === 'NotebookEdit') {
+    return HASH_API.test(inputText(toolInput));
+  }
+  return detectCodexHashIntent(name, toolInput);
+}
+
+function detectDependencyIntent(toolName, toolInput, cwd) {
+  const name = String(toolName || '');
+  if (name === 'PowerShell' || name === 'Monitor') {
+    return detectCodexDependencyIntent('Bash', toolInput);
+  }
+  if (name === 'Bash') {
+    return detectCodexDependencyIntent(name, toolInput);
+  }
+  if (name !== 'Write' && name !== 'Edit') return false;
+
+  const filePath = normalizePath(toolInput && (toolInput.file_path || toolInput.path), cwd);
+  if (!MANIFEST_PATH.test(filePath)) return false;
+
+  if (name === 'Write') {
+    return DEPENDENCY_DECLARATION.test(String(toolInput && toolInput.content || ''));
+  }
+  return DEPENDENCY_DECLARATION.test(String(toolInput && toolInput.new_string || ''));
+}
+
+module.exports = {
+  classifyClaudeTool,
+  detectDependencyIntent,
+  detectHashIntent,
+  extractAffectedPaths,
+  isUnboundedDelegation: (toolName) => String(toolName || '') === 'Workflow',
+  normalizePath
+};

--- a/src/controller.cjs
+++ b/src/controller.cjs
@@ -5,7 +5,7 @@ const { assertControlEvent } = require('./control-protocol.cjs');
 const { decide } = require('./decision.cjs');
 const { readRuntime, recordDecision } = require('./runtime-audit.cjs');
 const { recordAnnotation } = require('./runtime-annotations.cjs');
-const { readState, writeState } = require('./state.cjs');
+const { readState, withSessionLock, writeState } = require('./state.cjs');
 
 function none() {
   return { kind: 'none' };
@@ -126,21 +126,32 @@ function handlePrompt(event, options) {
 }
 
 function handleBeforeAction(event, options) {
-  const state = readState(event.sessionId, options.dataDir);
-  const action = {
-    mutability: event.action.mutability,
-    hashIntent: Boolean(event.action.hashIntent),
-    reachability: event.action.reachability,
-    authorization: event.action.authorization,
-    affectedPaths: event.action.affectedPaths,
-    dependencyIntent: Boolean(event.action.dependencyIntent)
-  };
-  const result = decide({ contract: state.contract, action, state });
+  const evaluate = () => {
+    const state = readState(event.sessionId, options.dataDir);
+    const action = {
+      mutability: event.action.mutability,
+      hashIntent: Boolean(event.action.hashIntent),
+      reachability: event.action.reachability,
+      authorization: event.action.authorization,
+      affectedPaths: event.action.affectedPaths,
+      dependencyIntent: Boolean(event.action.dependencyIntent),
+      unboundedDelegation: Boolean(event.action.unboundedDelegation)
+    };
+    const result = decide({ contract: state.contract, action, state });
 
-  if (event.action.mutability === 'delegate' && result.outcome === 'allow') {
-    state.contract.agentsUsed += 1;
-    writeState(event.sessionId, state, options.dataDir);
-  }
+    if (event.action.mutability === 'delegate' && result.outcome === 'allow') {
+      state.contract.agentsUsed += 1;
+      writeState(event.sessionId, state, options.dataDir);
+    }
+    return { state, result };
+  };
+
+  // Separate host processes can issue independent agent launches close together.
+  // Serialize only delegation reservations so agents=N remains a real budget
+  // across separate Hook processes without adding locks to the common fast path.
+  const { state, result } = event.action.mutability === 'delegate'
+    ? withSessionLock(event.sessionId, options.dataDir, evaluate)
+    : evaluate();
 
   const responseOutcome = result.outcome === 'deny_and_explain' || result.outcome === 'require_user_approval'
     ? 'permission_deny_returned'

--- a/src/decision.cjs
+++ b/src/decision.cjs
@@ -99,6 +99,16 @@ function decide({ contract, action, state = {} }) {
     );
   }
 
+  if (action.mutability === 'delegate' && action.unboundedDelegation) {
+    return decision(
+      controlledOutcome(level),
+      'S',
+      'UNBOUNDED_DELEGATION',
+      'The proposed delegation can fan out to an unbounded number of subagents, so it cannot satisfy agents=N deterministically.',
+      'Use explicit Agent calls within agents=N, or disable the Guard for a deliberately unbounded workflow.'
+    );
+  }
+
   if (action.mutability === 'delegate' && contract.agentsUsed >= contract.agentBudget) {
     return decision(
       controlledOutcome(level),

--- a/src/runtime-audit.cjs
+++ b/src/runtime-audit.cjs
@@ -40,7 +40,8 @@ function recordDecision(facts, options = {}) {
       mutability: String(action.mutability || 'unknown'),
       pathCount: Array.isArray(action.affectedPaths) ? action.affectedPaths.length : 0,
       hashIntent: Boolean(action.hashIntent),
-      dependencyIntent: Boolean(action.dependencyIntent)
+      dependencyIntent: Boolean(action.dependencyIntent),
+      unboundedDelegation: Boolean(action.unboundedDelegation)
     },
     contract: {
       mode: String(contract.mode || 'unconfirmed'),

--- a/src/state.cjs
+++ b/src/state.cjs
@@ -55,11 +55,75 @@ function writeState(sessionId, state, override) {
   }
 }
 
+
+function lockPath(sessionId, override) {
+  return `${statePath(sessionId, override)}.lock`;
+}
+
+function sleepSync(milliseconds) {
+  const shared = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(shared, 0, 0, milliseconds);
+}
+
+function acquireSessionLock(sessionId, override, options = {}) {
+  const file = lockPath(sessionId, override);
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : 1500;
+  const staleMs = Number.isFinite(options.staleMs) ? options.staleMs : 10000;
+  const started = Date.now();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+
+  while (true) {
+    try {
+      const fd = fs.openSync(file, 'wx', 0o600);
+      const token = `${process.pid}:${crypto.randomUUID()}`;
+      fs.writeFileSync(fd, `${token} ${Date.now()}\n`, 'utf8');
+      return () => {
+        try { fs.closeSync(fd); } catch {}
+        try {
+          const owner = fs.readFileSync(file, 'utf8').trim().split(/\s+/, 1)[0];
+          if (owner === token) fs.unlinkSync(file);
+        } catch (error) {
+          if (!error || error.code !== 'ENOENT') throw error;
+        }
+      };
+    } catch (error) {
+      if (!error || error.code !== 'EEXIST') throw error;
+      try {
+        const stat = fs.statSync(file);
+        if (Date.now() - stat.mtimeMs > staleMs) {
+          fs.unlinkSync(file);
+          continue;
+        }
+      } catch (statError) {
+        if (statError && statError.code === 'ENOENT') continue;
+        throw statError;
+      }
+      if (Date.now() - started >= timeoutMs) {
+        const timeout = new Error(`Timed out waiting for Stop That Shit session lock: ${sessionKey(sessionId)}`);
+        timeout.code = 'STS_LOCK_TIMEOUT';
+        throw timeout;
+      }
+      sleepSync(10);
+    }
+  }
+}
+
+function withSessionLock(sessionId, override, fn, options) {
+  const release = acquireSessionLock(sessionId, override, options);
+  try {
+    return fn();
+  } finally {
+    release();
+  }
+}
+
 module.exports = {
+  acquireSessionLock,
   dataRoot,
   freshState,
   readState,
   sessionKey,
   statePath,
+  withSessionLock,
   writeState
 };

--- a/test/claude-adapter.test.cjs
+++ b/test/claude-adapter.test.cjs
@@ -1,0 +1,269 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+const { handleClaudeHook, toControlEvent } = require('../src/adapters/claude-hooks.cjs');
+const { classifyClaudeTool, extractAffectedPaths, normalizePath } = require('../src/adapters/claude-tool-classifier.cjs');
+const { readState } = require('../src/state.cjs');
+
+const root = path.join(__dirname, '..');
+
+function workspace(t) {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sts-claude-test-'));
+  t.after(() => fs.rmSync(dataDir, { recursive: true, force: true }));
+  return { dataDir };
+}
+
+function prompt(session, text, cwd = root) {
+  return { session_id: session, hook_event_name: 'UserPromptSubmit', prompt: text, cwd, permission_mode: 'default' };
+}
+
+function expansion(session, args, commandName = 'stop-that-shit:stop-that-shit') {
+  return {
+    session_id: session,
+    hook_event_name: 'UserPromptExpansion',
+    expansion_type: 'slash_command',
+    command_name: commandName,
+    command_args: args,
+    cwd: root
+  };
+}
+
+function pre(session, toolName, toolInput, cwd = root) {
+  return {
+    session_id: session,
+    hook_event_name: 'PreToolUse',
+    tool_name: toolName,
+    tool_use_id: `${toolName}-1`,
+    tool_input: toolInput,
+    cwd,
+    permission_mode: 'default'
+  };
+}
+
+test('Claude Adapter maps official Hook fields to ControlEvent v1', () => {
+  const event = toControlEvent(pre('map-session', 'NotebookEdit', {
+    notebook_path: path.join(root, 'notebooks', 'demo.ipynb'),
+    new_source: 'print(1)'
+  }));
+  assert.equal(event.kind, 'action.before');
+  assert.equal(event.host.family, 'claude-code');
+  assert.equal(event.host.permissionMode, 'default');
+  assert.equal(event.action.mutability, 'write');
+  assert.deepEqual(event.action.affectedPaths, ['notebooks/demo.ipynb']);
+});
+
+test('review contract blocks Claude Write', (t) => {
+  const options = workspace(t);
+  handleClaudeHook(prompt('claude-review', '$stop-that-shit review -- inspect only'), options);
+  const output = handleClaudeHook(pre('claude-review', 'Write', { file_path: path.join(root, 'tmp.txt'), content: 'x' }), options);
+  assert.equal(output.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(output.hookSpecificOutput.permissionDecisionReason, /I\/MODE_FORBIDS_MUTATION/);
+});
+
+test('direct plugin slash invocation arms the same review contract before expansion', (t) => {
+  const options = workspace(t);
+  const context = handleClaudeHook(expansion('slash-review', 'review -- inspect only'), options);
+  assert.match(context.hookSpecificOutput.additionalContext, /mode=review/);
+  assert.equal(readState('slash-review', options.dataDir).contract.mode, 'review');
+  const denied = handleClaudeHook(pre('slash-review', 'Edit', {
+    file_path: path.join(root, 'src', 'state.cjs'), old_string: 'a', new_string: 'b'
+  }), options);
+  assert.equal(denied.hookSpecificOutput.permissionDecision, 'deny');
+});
+
+test('unrelated slash expansion is ignored', (t) => {
+  const options = workspace(t);
+  assert.equal(handleClaudeHook(expansion('slash-other', 'review', 'other-plugin:review'), options), null);
+  assert.equal(readState('slash-other', options.dataDir).contract.mode, 'unconfirmed');
+});
+
+test('slash invocation through UserPromptSubmit arms hosts without UserPromptExpansion', (t) => {
+  const options = workspace(t);
+  const context = handleClaudeHook(prompt('slash-submit', '/stop-that-shit:stop-that-shit review -- inspect only'), options);
+  assert.match(context.hookSpecificOutput.additionalContext, /mode=review/);
+  assert.equal(readState('slash-submit', options.dataDir).contract.mode, 'review');
+  const denied = handleClaudeHook(pre('slash-submit', 'Edit', {
+    file_path: path.join(root, 'src', 'state.cjs'), old_string: 'a', new_string: 'b'
+  }), options);
+  assert.equal(denied.hookSpecificOutput.permissionDecision, 'deny');
+
+  const bare = handleClaudeHook(prompt('slash-bare', '/stop-that-shit change -- fix it'), options);
+  assert.equal(readState('slash-bare', options.dataDir).contract.mode, 'change');
+  assert.ok(bare === null || /mode=change/.test(bare.hookSpecificOutput.additionalContext));
+});
+
+test('plain prose not starting with the slash form stays on the normal prompt path', (t) => {
+  const options = workspace(t);
+  const output = handleClaudeHook(prompt('plain', 'review this diff please'), options);
+  assert.equal(readState('plain', options.dataDir).contract.mode, 'unconfirmed');
+  assert.ok(output === null || !/mode=review/.test(output.hookSpecificOutput.additionalContext));
+});
+
+test('Claude absolute paths are normalized and file locks enforce only writes', (t) => {
+  const options = workspace(t);
+  handleClaudeHook(prompt('path-lock', '$stop-that-shit lock change files=src/state.cjs -- edit only state'), options);
+
+  assert.equal(handleClaudeHook(pre('path-lock', 'Edit', {
+    file_path: path.join(root, 'src', 'state.cjs'), old_string: 'a', new_string: 'b'
+  }), options), null);
+
+  const denied = handleClaudeHook(pre('path-lock', 'Write', {
+    file_path: path.join(root, 'README.md'), content: 'x'
+  }), options);
+  assert.equal(denied.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(denied.hookSpecificOutput.permissionDecisionReason, /S\/PATH_OUTSIDE_CONTRACT/);
+
+  // A read-only MCP-style tool with a path must not be converted into a write-scope decision.
+  assert.deepEqual(extractAffectedPaths('mcp__fs__read_file', { path: path.join(root, 'README.md') }, root), []);
+});
+
+test('Windows absolute paths normalize relative to a Windows hook cwd', () => {
+  assert.equal(normalizePath('C:\\repo\\src\\ok.js', 'C:\\repo'), 'src/ok.js');
+  const outside = normalizePath('D:\\other\\no.js', 'C:\\repo');
+  assert.ok(outside !== 'src/ok.js');
+  assert.ok(outside.includes('D:') || outside.startsWith('../'));
+});
+
+test('NotebookEdit participates in review and file-lock enforcement', (t) => {
+  const options = workspace(t);
+  handleClaudeHook(prompt('notebook-review', '$stop-that-shit review -- inspect notebook'), options);
+  const reviewDenied = handleClaudeHook(pre('notebook-review', 'NotebookEdit', {
+    notebook_path: path.join(root, 'demo.ipynb'), new_source: '1 + 1'
+  }), options);
+  assert.equal(reviewDenied.hookSpecificOutput.permissionDecision, 'deny');
+
+  handleClaudeHook(prompt('notebook-lock', '$stop-that-shit lock change files=allowed.ipynb -- edit one notebook'), options);
+  const scopeDenied = handleClaudeHook(pre('notebook-lock', 'NotebookEdit', {
+    notebook_path: path.join(root, 'other.ipynb'), new_source: '1 + 1'
+  }), options);
+  assert.match(scopeDenied.hookSpecificOutput.permissionDecisionReason, /S\/PATH_OUTSIDE_CONTRACT/);
+});
+
+test('PowerShell and manifest edits preserve dependency authority', (t) => {
+  const options = workspace(t);
+  handleClaudeHook(prompt('deps-ps', '$stop-that-shit change -- change one value'), options);
+  const shellDenied = handleClaudeHook(pre('deps-ps', 'PowerShell', { command: 'npm install lodash' }), options);
+  assert.match(shellDenied.hookSpecificOutput.permissionDecisionReason, /S\/DEPENDENCY_NOT_AUTHORIZED/);
+
+  handleClaudeHook(prompt('deps-write', '$stop-that-shit change -- update package metadata'), options);
+  const fileDenied = handleClaudeHook(pre('deps-write', 'Write', {
+    file_path: path.join(root, 'package.json'),
+    content: '{"dependencies":{"lodash":"^4.17.21"}}'
+  }), options);
+  assert.match(fileDenied.hookSpecificOutput.permissionDecisionReason, /S\/DEPENDENCY_NOT_AUTHORIZED/);
+});
+
+test('Monitor command sources reuse shell hash/dependency enforcement while WebSocket monitors stay read-only', (t) => {
+  const options = workspace(t);
+  handleClaudeHook(prompt('monitor-deps', '$stop-that-shit change -- observe the build'), options);
+  const dependencyDenied = handleClaudeHook(pre('monitor-deps', 'Monitor', { command: 'npm install lodash' }), options);
+  assert.match(dependencyDenied.hookSpecificOutput.permissionDecisionReason, /S\/DEPENDENCY_NOT_AUTHORIZED/);
+
+  handleClaudeHook(prompt('monitor-hash', '$stop-that-shit change deps=allow -- observe checks'), options);
+  const hashDenied = handleClaudeHook(pre('monitor-hash', 'Monitor', { command: 'sha256sum artifact.bin' }), options);
+  assert.match(hashDenied.hookSpecificOutput.permissionDecisionReason, /H\/HASH_NOT_AUTHORIZED/);
+  assert.equal(classifyClaudeTool('Monitor', { ws: { url: 'wss://example.test/events' } }), 'read');
+});
+
+test('Claude Agent uses the shared subagent budget', (t) => {
+  const options = workspace(t);
+  handleClaudeHook(prompt('agent-budget', '$stop-that-shit change agents=1 -- use one specialist'), options);
+  assert.equal(handleClaudeHook(pre('agent-budget', 'Agent', { prompt: 'inspect tests' }), options), null);
+  const denied = handleClaudeHook(pre('agent-budget', 'Agent', { prompt: 'inspect docs' }), options);
+  assert.match(denied.hookSpecificOutput.permissionDecisionReason, /S\/AGENT_BUDGET_EXHAUSTED/);
+});
+
+test('Claude Workflow cannot bypass agents=N with opaque internal fan-out', (t) => {
+  const options = workspace(t);
+  handleClaudeHook(prompt('workflow-budget', '$stop-that-shit change agents=8 -- bounded delegation only'), options);
+  const denied = handleClaudeHook(pre('workflow-budget', 'Workflow', { workflow: 'parallel-review' }), options);
+  assert.match(denied.hookSpecificOutput.permissionDecisionReason, /S\/UNBOUNDED_DELEGATION/);
+  assert.equal(readState('workflow-budget', options.dataDir).contract.agentsUsed, 0);
+});
+
+test('newer Claude built-ins classify without weakening read-only and worktree boundaries', () => {
+  assert.equal(classifyClaudeTool('LSP', { operation: 'goToDefinition' }), 'read');
+  assert.equal(classifyClaudeTool('ListMcpResourcesTool', {}), 'read');
+  assert.equal(classifyClaudeTool('EnterPlanMode', {}), 'control');
+  assert.equal(classifyClaudeTool('ReportFindings', {}), 'control');
+  assert.equal(classifyClaudeTool('EnterWorktree', {}), 'write');
+  assert.equal(classifyClaudeTool('Workflow', {}), 'delegate');
+});
+
+test('SessionStart and SubagentStart inject current contract context', (t) => {
+  const options = workspace(t);
+  const initial = handleClaudeHook({ session_id: 'life', hook_event_name: 'SessionStart', source: 'startup', cwd: root }, options);
+  assert.match(initial.hookSpecificOutput.additionalContext, /watch-only mode/);
+  handleClaudeHook(prompt('life', '$stop-that-shit review -- inspect only'), options);
+  const subagent = handleClaudeHook({ session_id: 'life', hook_event_name: 'SubagentStart', agent_id: 'a1', agent_type: 'Explore', cwd: root }, options);
+  assert.equal(subagent.hookSpecificOutput.hookEventName, 'SubagentStart');
+  assert.match(subagent.hookSpecificOutput.additionalContext, /mode=review/);
+});
+
+test('Claude hook entrypoint runs from CLAUDE_PLUGIN_ROOT and persists in CLAUDE_PLUGIN_DATA', (t) => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sts-claude-entry-'));
+  t.after(() => fs.rmSync(dataDir, { recursive: true, force: true }));
+  const entrypoint = path.join(root, 'hooks', 'stop-that-shit-claude.cjs');
+  const first = spawnSync(process.execPath, [entrypoint], {
+    cwd: root,
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: root, CLAUDE_PLUGIN_DATA: dataDir },
+    input: JSON.stringify(expansion('entry-session', 'review -- inspect only')),
+    encoding: 'utf8', timeout: 5000
+  });
+  assert.equal(first.status, 0, first.stderr);
+  assert.match(JSON.parse(first.stdout).hookSpecificOutput.additionalContext, /mode=review/);
+
+  const second = spawnSync(process.execPath, [entrypoint], {
+    cwd: root,
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: root, CLAUDE_PLUGIN_DATA: dataDir },
+    input: JSON.stringify(pre('entry-session', 'Write', { file_path: path.join(root, 'x.txt'), content: 'x' })),
+    encoding: 'utf8', timeout: 5000
+  });
+  assert.equal(second.status, 0, second.stderr);
+  assert.equal(JSON.parse(second.stdout).hookSpecificOutput.permissionDecision, 'deny');
+});
+
+test('Claude tool classification covers native read, write, control, delegation, and unknown tools', () => {
+  assert.equal(classifyClaudeTool('Read', { file_path: 'x' }), 'read');
+  assert.equal(classifyClaudeTool('Write', { file_path: 'x' }), 'write');
+  assert.equal(classifyClaudeTool('NotebookEdit', { notebook_path: 'x' }), 'write');
+  assert.equal(classifyClaudeTool('Agent', {}), 'delegate');
+  assert.equal(classifyClaudeTool('AskUserQuestion', {}), 'control');
+  assert.equal(classifyClaudeTool('Bash', { command: 'git diff --stat' }), 'read');
+  assert.equal(classifyClaudeTool('PowerShell', { command: 'Get-Content README.md' }), 'read');
+  assert.equal(classifyClaudeTool('Bash', { command: 'node scripts/custom.js' }), 'unknown');
+});
+
+test('parallel Claude Agent hook processes cannot oversubscribe agents=1', (t) => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sts-claude-parallel-'));
+  t.after(() => fs.rmSync(dataDir, { recursive: true, force: true }));
+  handleClaudeHook(prompt('parallel-agent', '$stop-that-shit change agents=1 -- one subagent'), { dataDir });
+  const entrypoint = path.join(root, 'hooks', 'stop-that-shit-claude.cjs');
+  const payload = JSON.stringify(pre('parallel-agent', 'Agent', { prompt: 'inspect' }));
+  const children = [0, 1].map(() => require('node:child_process').spawn(process.execPath, [entrypoint], {
+    cwd: root,
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: root, CLAUDE_PLUGIN_DATA: dataDir },
+    stdio: ['pipe', 'pipe', 'pipe']
+  }));
+  for (const child of children) child.stdin.end(payload);
+  return Promise.all(children.map((child) => new Promise((resolve, reject) => {
+    let stdout = ''; let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  }))).then((results) => {
+    assert.deepEqual(results.map((r) => r.code), [0, 0], results.map((r) => r.stderr).join('\n'));
+    const parsed = results.map((r) => r.stdout.trim() ? JSON.parse(r.stdout) : null);
+    const denied = parsed.filter((value) => value?.hookSpecificOutput?.permissionDecision === 'deny');
+    const allowed = parsed.filter((value) => value === null);
+    assert.equal(denied.length, 1);
+    assert.equal(allowed.length, 1);
+    assert.equal(readState('parallel-agent', dataDir).contract.agentsUsed, 1);
+  });
+});

--- a/test/claude-plugin.test.cjs
+++ b/test/claude-plugin.test.cjs
@@ -1,0 +1,63 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.join(__dirname, '..');
+const readJson = (...parts) => JSON.parse(fs.readFileSync(path.join(root, ...parts), 'utf8'));
+
+test('Claude plugin manifest uses default skills and hooks surfaces', () => {
+  const pkg = readJson('package.json');
+  const manifest = readJson('.claude-plugin', 'plugin.json');
+  assert.equal(manifest.name, 'stop-that-shit');
+  assert.equal(manifest.version, pkg.version);
+  assert.equal(manifest.skills, './skills/');
+  // The standard hooks/hooks.json location is auto-loaded; manifest.hooks
+  // must not re-declare it, or hosts reject the duplicate registration.
+  assert.equal(Object.hasOwn(manifest, 'hooks'), false);
+  assert.ok(fs.existsSync(path.join(root, 'hooks', 'stop-that-shit-claude.cjs')));
+});
+
+test('Claude hooks register only events every supported host accepts', () => {
+  const config = readJson('hooks', 'hooks.json');
+  assert.deepEqual(Object.keys(config.hooks).sort(), [
+    'PreToolUse', 'SessionStart', 'SubagentStart', 'UserPromptSubmit'
+  ]);
+  for (const groups of Object.values(config.hooks)) {
+    for (const group of groups) {
+      for (const hook of group.hooks) {
+        assert.equal(hook.type, 'command');
+        // Shell form (no args array) so hosts that only accept a command
+        // string, such as cc-haha, still resolve the entrypoint.
+        assert.equal(hook.command, 'node "${CLAUDE_PLUGIN_ROOT}/hooks/stop-that-shit-claude.cjs"');
+        assert.equal(Object.hasOwn(hook, 'args'), false);
+        assert.ok(hook.timeout > 0);
+      }
+    }
+  }
+});
+
+test('local Claude marketplace points at the plugin root and leaves version to plugin.json', () => {
+  const marketplace = readJson('.claude-plugin', 'marketplace.json');
+  assert.equal(marketplace.name, 'stop-that-shit');
+  assert.equal(marketplace.plugins[0].name, 'stop-that-shit');
+  assert.equal(marketplace.plugins[0].source, './');
+  assert.equal(Object.hasOwn(marketplace.plugins[0], 'version'), false);
+});
+
+test('Codex manifest keeps the original two-hook surface', () => {
+  const manifest = readJson('.codex-plugin', 'plugin.json');
+  const hooks = readJson('hooks', 'codex-hooks.json');
+  assert.equal(manifest.hooks, './hooks/codex-hooks.json');
+  assert.deepEqual(Object.keys(hooks.hooks).sort(), ['PreToolUse', 'UserPromptSubmit']);
+});
+
+test('shared Skill documents both Claude Code and Codex invocation forms', () => {
+  const skill = fs.readFileSync(path.join(root, 'skills', 'stop-that-shit', 'SKILL.md'), 'utf8');
+  assert.match(skill, /Claude Code/i);
+  assert.match(skill, /\/stop-that-shit:stop-that-shit review/);
+  assert.match(skill, /\$stop-that-shit review/);
+  assert.match(skill, /works without the Guard/i);
+});

--- a/test/opencode-smoke.test.cjs
+++ b/test/opencode-smoke.test.cjs
@@ -30,14 +30,9 @@ function runOpencode(args, options = {}) {
 }
 
 const versionProbe = spawnSync('opencode', ['--version'], { encoding: 'utf8', timeout: 30000 });
-const versionMatch = String(versionProbe.stdout || '').trim().match(/^(\d+)\.(\d+)\.(\d+)/);
-const hasSupportedOpencode = !versionProbe.error && versionProbe.status === 0 && versionMatch && (
-  Number(versionMatch[1]) > 1
-  || (Number(versionMatch[1]) === 1 && Number(versionMatch[2]) > 18)
-  || (Number(versionMatch[1]) === 1 && Number(versionMatch[2]) === 18 && Number(versionMatch[3]) >= 18)
-);
+const hasOpencode = !versionProbe.error && versionProbe.status === 0;
 
-test('installed OpenCode plugin denies a write under a review contract', { skip: !hasSupportedOpencode, timeout: 300000 }, async (t) => {
+test('installed OpenCode plugin denies a write under a review contract', { skip: !hasOpencode, timeout: 300000 }, async (t) => {
   const work = fs.mkdtempSync(path.join(os.tmpdir(), 'sts-opencode-smoke-'));
   t.after(() => fs.rmSync(work, { recursive: true, force: true }));
   const workspace = path.join(work, 'ws');
@@ -55,11 +50,7 @@ test('installed OpenCode plugin denies a write under a review contract', { skip:
 
   // Pack the repository so the test exercises the same package shape that
   // `opencode plugin github:lennney/stop-that-shit -g` installs.
-  assert.ok(process.env.npm_execpath, 'npm_execpath is required for the package smoke test');
-  const pack = spawnSync(process.execPath, [
-    process.env.npm_execpath,
-    'pack', '--json', '--pack-destination', work
-  ], {
+  const pack = spawnSync('npm', ['pack', '--json', '--pack-destination', work], {
     cwd: root,
     encoding: 'utf8',
     timeout: 120000

--- a/test/plugin.test.cjs
+++ b/test/plugin.test.cjs
@@ -9,12 +9,12 @@ const test = require('node:test');
 
 const root = path.join(__dirname, '..');
 
-test('plugin manifest and default hook discovery paths exist', () => {
+test('Codex plugin manifest and its preserved hook discovery paths exist', () => {
   const manifest = JSON.parse(fs.readFileSync(path.join(root, '.codex-plugin', 'plugin.json'), 'utf8'));
-  const hooks = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'hooks.json'), 'utf8'));
+  const hooks = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'codex-hooks.json'), 'utf8'));
   assert.equal(manifest.name, 'stop-that-shit');
+  assert.equal(manifest.hooks, './hooks/codex-hooks.json');
   assert.ok(fs.existsSync(path.join(root, 'skills', 'stop-that-shit', 'SKILL.md')));
-  assert.ok(fs.existsSync(path.join(root, 'hooks', 'hooks.json')));
   assert.deepEqual(Object.keys(hooks.hooks).sort(), ['PreToolUse', 'UserPromptSubmit']);
 });
 
@@ -25,8 +25,8 @@ test('the packaged Skill remains useful without the Guard hooks', () => {
   assert.match(skill, /Do the requested work\. Keep necessary consequences\. Stop everything else\./);
 });
 
-test('hook commands resolve the plugin root inside Node and are shell-agnostic', () => {
-  const config = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'hooks.json'), 'utf8'));
+test('Codex hook commands keep resolving the plugin root inside Node and stay shell-agnostic', () => {
+  const config = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'codex-hooks.json'), 'utf8'));
   const handlers = Object.values(config.hooks).flat().flatMap((group) => group.hooks);
   assert.ok(handlers.length > 0);
   for (const handler of handlers) {
@@ -36,12 +36,12 @@ test('hook commands resolve the plugin root inside Node and are shell-agnostic',
   }
 });
 
-test('the packaged hook entrypoint accepts a Codex event on stdin', (t) => {
+test('the packaged Codex hook entrypoint still accepts a Codex event on stdin', (t) => {
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sts-entrypoint-'));
   t.after(() => fs.rmSync(dataDir, { recursive: true, force: true }));
-  const hook = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'hooks.json'), 'utf8'))
+  const hook = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'codex-hooks.json'), 'utf8'))
     .hooks.UserPromptSubmit[0].hooks[0];
-  const source = hook.command.match(/^node -e \"([\s\S]+)\"$/)[1];
+  const source = hook.command.match(/^node -e "([\s\S]+)"$/)[1];
   const input = JSON.stringify({
     session_id: 'entrypoint-session',
     turn_id: 'turn-1',


### PR DESCRIPTION
## Case

This PR adds a Claude Code host plugin (Skill + Hook surface) while preserving the shared decision policy and the existing Codex case corpus.

The executable policy corpus now contains 16 case arms. The pair changes the `unboundedDelegation` fact while keeping the task mode, agent budget, and necessary-consequence authorization aligned.

## Scope

The Claude Code plugin surface (`.claude-plugin/`, `hooks/hooks.json`, `hooks/stop-that-shit-claude.cjs`), the Codex manifest's preserved hook path (`hooks/codex-hooks.json`, `.codex-plugin/plugin.json`), the shared controller and decision additions required by the Claude adapter (`src/adapters/claude-*.cjs`, `src/state.cjs`, `src/controller.cjs`, `src/decision.cjs`, `src/runtime-audit.cjs`), related tests, the shared Skill, installation and architecture documentation, the `STS-S-006` case pair, and release verification.


## Change

Add a Claude Code plugin that reuses the existing core. A thin adapter normalizes `SessionStart`, `UserPromptSubmit`, `PreToolUse`, and `SubagentStart` into `ControlEvent v1`, classifies Claude-native tools, and returns `permissionDecision: deny` for covered violations.

Direct `/stop-that-shit:stop-that-shit` invocation is armed from `UserPromptSubmit`, so it works on hosts without `UserPromptExpansion`. `Workflow` is treated as unbounded delegation and denied when the Guard is armed. Concurrent delegation reservations are serialized so `agents=N` remains a deterministic budget. The Codex plugin keeps its original two-event surface, declared in `hooks/codex-hooks.json`.

## Evidence

- [x] `npm ci` completes successfully.
- [x] `npm test` completes with 142 passed, 1 optional OpenCode installed-host smoke skipped, and 0 failed.
- [x] `npm run eval` passes 16/16 executable Bad/Good case arms.
- [x] `npm run release:check` passes with the 117-file multi-host release allowlist.
- [x] `STS-S-006-B` returns `deny_and_explain / S / UNBOUNDED_DELEGATION`.
- [x] `STS-S-006-G` returns `allow / WITHIN_CONTRACT`.
- [x] The requested bounded delegation Good Case still proceeds.
- [x] The Claude marketplace manifest and all four installation documents use the checkout root.
- [x] No unrelated file was reformatted or reorganized.
- [x] No private material or internal research is included.
- [x] No paid Codex evaluation was started without maintainer approval.

## Limitations

- Claude Code was smoke-tested live once on a local Windows host (`review` denial, `change` allow, and file-lock denial); live macOS/Linux smoke testing and other Claude CLI versions are not covered.
- `Workflow` fan-out denial is conservative. The deterministic Bad/Good pair covers the policy boundary, but the denial was not exercised against a live workflow that legitimately required subagents.
- MCP and third-party plugin tools fall back to the existing name classifier and are not individually verified.
- The optional installed OpenCode smoke runs only when OpenCode 1.18.18 or newer is available.
- The 72-session paid paired-eval matrix was not run.