### PR TITLE
fix: use valid local Claude marketplace path

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ checkout as a local Claude marketplace, then install the plugin:
 
 ```bash
 claude plugin validate .
-claude plugin marketplace add .
+claude plugin marketplace add ./
 claude plugin install stop-that-shit@stop-that-shit
 ```
 

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -16,7 +16,7 @@ configuration, copy authentication files, or bypass Hook review.
 3. Add the local marketplace and install the plugin:
 
    ```bash
-   claude plugin marketplace add .
+   claude plugin marketplace add ./
    claude plugin install stop-that-shit@stop-that-shit
    ```
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Extract the repository, then from the checkout root:
 
 ```bash
 claude plugin validate .
-claude plugin marketplace add .
+claude plugin marketplace add ./
 claude plugin install stop-that-shit@stop-that-shit
 ```
 
@@ -267,7 +267,7 @@ Requires Node.js 18 or newer. From the local checkout root:
 
 ```bash
 claude plugin validate .
-claude plugin marketplace add .
+claude plugin marketplace add ./
 claude plugin install stop-that-shit@stop-that-shit
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -56,7 +56,7 @@ Event: evt_...
 
 ```bash
 claude plugin validate .
-claude plugin marketplace add .
+claude plugin marketplace add ./
 claude plugin install stop-that-shit@stop-that-shit
 ```
 
@@ -221,7 +221,7 @@ Skill 负责语义判断。Hook 在受支持的工具运行前检查明确事实
 
 ```bash
 claude plugin validate .
-claude plugin marketplace add .
+claude plugin marketplace add ./
 claude plugin install stop-that-shit@stop-that-shit
 ```
 

--- a/test/claude-plugin.test.cjs
+++ b/test/claude-plugin.test.cjs
@@ -47,6 +47,15 @@ test('local Claude marketplace points at the plugin root and leaves version to p
   assert.equal(Object.hasOwn(marketplace.plugins[0], 'version'), false);
 });
 
+test('Claude local install docs use an explicit relative marketplace path', () => {
+  for (const file of ['README.md', 'README_CN.md', 'INSTALL.md']) {
+    const contents = fs.readFileSync(path.join(root, file), 'utf8');
+    const commands = contents.match(/^claude plugin marketplace add .*$/gm) || [];
+    assert.ok(commands.length > 0, `${file} must document the marketplace command`);
+    assert.deepEqual([...new Set(commands)], ['claude plugin marketplace add ./']);
+  }
+});
+
 test('Codex manifest keeps the original two-hook surface', () => {
   const manifest = readJson('.codex-plugin', 'plugin.json');
   const hooks = readJson('hooks', 'codex-hooks.json');

--- a/test/claude-plugin.test.cjs
+++ b/test/claude-plugin.test.cjs
@@ -48,9 +48,10 @@ test('local Claude marketplace points at the plugin root and leaves version to p
 });
 
 test('Claude local install docs use an explicit relative marketplace path', () => {
-  for (const file of ['README.md', 'README_CN.md', 'INSTALL.md']) {
+  for (const file of ['README.md', 'README_CN.md', 'INSTALL.md', 'INSTALL_FOR_AGENTS.md']) {
     const contents = fs.readFileSync(path.join(root, file), 'utf8');
-    const commands = contents.match(/^claude plugin marketplace add .*$/gm) || [];
+    const commands = (contents.match(/^\s*claude plugin marketplace add .*$/gm) || [])
+      .map((command) => command.trim());
     assert.ok(commands.length > 0, `${file} must document the marketplace command`);
     assert.deepEqual([...new Set(commands)], ['claude plugin marketplace add ./']);
   }


### PR DESCRIPTION
## Summary

- replace the invalid local Claude marketplace source `.` with the accepted explicit relative path `./`
- update both README files and the installation guide
- add regression coverage for every documented Claude marketplace command

## Root cause

`claude plugin validate .` accepts the current directory, but `claude plugin marketplace add .` rejects it because local marketplace sources must use an explicit relative path such as `./path`. From the checkout root, `./` is the equivalent accepted form.

## User impact

Users can now copy the documented Claude Code installation commands without leaving the repository root or rewriting the marketplace path.

## Validation

Tested with Claude Code `2.1.227` in an isolated `CLAUDE_CONFIG_DIR`:

- `claude plugin validate .` passed
- `claude plugin marketplace add .` reproduced `Invalid marketplace source format`
- `claude plugin marketplace add ./` passed
- `claude plugin install stop-that-shit@stop-that-shit` passed
- the installed plugin reported all four packaged hooks

Repository checks:

- `npm test`
- `npm run eval`
- `npm run release:check`
- `git diff --check`

Fixes #8