### PR TITLE
chore: complete plugin distribution metadata

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "stop-that-shit",
   "interface": {
-    "displayName": "Stop That Shit"
+    "displayName": "Stop That Shit（别再造史了）"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stop-that-shit",
-  "displayName": "Stop That Shit",
+  "displayName": "Stop That Shit（别再造史了）",
   "version": "0.0.3",
   "description": "Keep Claude Code on task with local-first mode, scope, dependency, hash, and delegation guardrails.",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -18,7 +18,7 @@
   "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "interface": {
-    "displayName": "Stop That Shit",
+    "displayName": "Stop That Shit（别再造史了）",
     "shortDescription": "Stop small Codex tasks from growing extra machinery.",
     "longDescription": "Stop That Shit runs locally and blocks unneeded scope, subagents, dependencies, and hashes in Codex tasks.",
     "developerName": "Stop That Shit contributors",
@@ -29,9 +29,11 @@
     ],
     "websiteURL": "https://github.com/lennney/stop-that-shit",
     "privacyPolicyURL": "https://github.com/lennney/stop-that-shit/blob/main/PRIVACY.md",
+    "termsOfServiceURL": "https://github.com/lennney/stop-that-shit/blob/main/LICENSE",
     "brandColor": "#D92D20",
     "composerIcon": "./assets/stop-icon.svg",
     "logo": "./assets/stop-icon.svg",
+    "screenshots": "./assets/stop-stamp.svg",
     "defaultPrompt": [
       "$stop-that-shit review -- Review this diff. Report findings; do not edit.",
       "$stop-that-shit change -- Fix the failing test only.",


### PR DESCRIPTION
## Summary

- Add the Chinese product display name across the plugin marketplace manifests.
- Add the Codex terms-of-service and screenshots metadata required by distribution/scanner checks.
- Keep the package version and runtime behavior unchanged.

## Validation

- `node --test test/claude-plugin.test.cjs` — 6 passed
- `npm run release:check` — passed (119 files, version 0.0.3, multi-host)

This is the release/distribution metadata slice extracted from #13. It does not publish a release or bump the version. The original PR remains open as a draft until the split PRs are reviewed.