### PR TITLE
chore: prepare 0.1.0 multi-platform release

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "stop-that-shit",
   "interface": {
-    "displayName": "Stop That Shit"
+    "displayName": "Stop That Shit（别再造史了）"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stop-that-shit",
-  "displayName": "Stop That Shit",
+  "displayName": "Stop That Shit（别再造史了）",
   "version": "0.0.3",
   "description": "Keep Claude Code on task with local-first mode, scope, dependency, hash, and delegation guardrails.",
   "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stop-that-shit",
   "displayName": "Stop That Shit（别再造史了）",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Keep Claude Code on task with local-first mode, scope, dependency, hash, and delegation guardrails.",
   "author": {
     "name": "Stop That Shit contributors",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -33,7 +33,6 @@
     "brandColor": "#D92D20",
     "composerIcon": "./assets/stop-icon.svg",
     "logo": "./assets/stop-icon.svg",
-    "screenshots": "./assets/stop-stamp.svg",
     "defaultPrompt": [
       "$stop-that-shit review -- Review this diff. Report findings; do not edit.",
       "$stop-that-shit change -- Fix the failing test only.",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stop-that-shit",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Stop unneeded scope, subagents, dependencies, and hashes in Codex tasks.",
   "author": {
     "name": "Stop That Shit contributors",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -18,7 +18,7 @@
   "skills": "./skills/",
   "hooks": "./hooks/codex-hooks.json",
   "interface": {
-    "displayName": "Stop That Shit",
+    "displayName": "Stop That Shit（别再造史了）",
     "shortDescription": "Stop small Codex tasks from growing extra machinery.",
     "longDescription": "Stop That Shit runs locally and blocks unneeded scope, subagents, dependencies, and hashes in Codex tasks.",
     "developerName": "Stop That Shit contributors",
@@ -29,9 +29,11 @@
     ],
     "websiteURL": "https://github.com/lennney/stop-that-shit",
     "privacyPolicyURL": "https://github.com/lennney/stop-that-shit/blob/main/PRIVACY.md",
+    "termsOfServiceURL": "https://github.com/lennney/stop-that-shit/blob/main/LICENSE",
     "brandColor": "#D92D20",
     "composerIcon": "./assets/stop-icon.svg",
     "logo": "./assets/stop-icon.svg",
+    "screenshots": "./assets/stop-stamp.svg",
     "defaultPrompt": [
       "$stop-that-shit review -- Review this diff. Report findings; do not edit.",
       "$stop-that-shit change -- Fix the failing test only.",

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 .DS_Store
 Thumbs.db
 .claude/
+__pycache__/
+*.pyc

--- a/.hermes-plugin/.npmignore
+++ b/.hermes-plugin/.npmignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.hermes-plugin/plugin.yaml
+++ b/.hermes-plugin/plugin.yaml
@@ -1,6 +1,6 @@
 name: stop-that-shit
-version: "0.0.3"
-description: "Stop That Shit Hermes Agent plugin skeleton."
+version: "0.1.0"
+description: "Stop That Shit task-boundary Guard for Hermes Agent CLI."
 author: "Stop That Shit contributors"
 license: MIT
 manifest_version: 1

--- a/.hermes-plugin/runtime/stop-that-shit.cjs
+++ b/.hermes-plugin/runtime/stop-that-shit.cjs
@@ -781,9 +781,9 @@ module.exports = { readRuntime, recordDecision };
 "package.json": function(module, exports, __require) {
 module.exports = {
   "name": "stop-that-shit",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "private": true,
-  "description": "Stop unneeded scope, subagents, dependencies, and hashes in Codex, Claude Code, and OpenCode tasks",
+  "description": "Stop unneeded scope, subagents, dependencies, and hashes in Codex, Claude Code, OpenCode, and Hermes Agent CLI tasks",
   "license": "MIT",
   "main": "./opencode/stop-that-shit.mjs",
   "exports": {
@@ -1370,9 +1370,9 @@ module.exports = { classifyCodexTool, classifyShell, detectDependencyIntent, det
 };
 __modules["package.json"] = function(module) { module.exports = {
   "name": "stop-that-shit",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "private": true,
-  "description": "Stop unneeded scope, subagents, dependencies, and hashes in Codex, Claude Code, and OpenCode tasks",
+  "description": "Stop unneeded scope, subagents, dependencies, and hashes in Codex, Claude Code, OpenCode, and Hermes Agent CLI tasks",
   "license": "MIT",
   "main": "./opencode/stop-that-shit.mjs",
   "exports": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,133 @@
 
 ## Unreleased
 
-- Added an OpenCode adapter and GitHub-installable plugin entrypoint using only
-  documented OpenCode hooks (`message.part.updated` and session events through
-  `event`, plus `tool.execute.before`/`tool.execute.after`) and the documented
-  SDK (`client.session.message`, `client.session.prompt({ noReply: true })`).
-- Added package metadata for
-  `opencode plugin github:lennney/stop-that-shit -g` while keeping npm
-  publication disabled.
-- Added OpenCode-native tool classification, execution-denial audit outcomes,
-  deterministic adapter/plugin regression tests, and an installed-host smoke
-  test that packs the package, installs it into a real OpenCode 1.18.18, and
-  verifies a review contract denies a write without changing Codex Hook
-  behavior.
-- OpenCode: a non-directive root message under an edit-capable agent now
-  advances a `review` contract to `change` (`source: host`), so switching the
-  host to build mode no longer deadlocks implementation work behind a stale
-  review contract.
+No unreleased changes yet.
+
+## 0.1.0 — 2026-08-20 (First Multi-platform Release / 首个多平台版本)
+
+> **同一个任务边界核心，现在有四套宿主适配：Codex、Claude Code、
+> OpenCode 和 Hermes Agent CLI。** 0.1.0 是 Stop That Shit 的首个多平台
+> 正式版本。
+>
+> **One task-boundary core now has four host adapters: Codex, Claude Code,
+> OpenCode, and Hermes Agent CLI.** Version 0.1.0 is the first multi-platform
+> release of Stop That Shit.
+
+### 重点内容：你现在可以 / Highlights
+
+- 从同一个 GitHub tag 获取四种宿主的安装入口，同时继续共用同一份
+  Stop Ladder、合同状态、决策策略和只存元数据的 Runtime。
+  / Install four host entrypoints from one GitHub tag while sharing the same
+  Stop Ladder, contract state, decision policy, and metadata-only Runtime.
+- 在 Codex 与 Claude Code 中使用原生 Plugin + Hook，在 OpenCode 中使用
+  GitHub 安装的插件入口，在 Hermes Agent CLI 中使用原生 Plugin 回调。
+  / Use native Plugin and Hook surfaces in Codex and Claude Code, a
+  GitHub-installed plugin entrypoint in OpenCode, and native Plugin callbacks
+  in Hermes Agent CLI.
+- 保留每个宿主自己的安装、信任与重启流程；统一的是版本和核心，不是假装
+  四个平台拥有完全相同的生命周期。
+  / Keep each host's own installation, trust, and restart lifecycle; the shared
+  contract is the version and core, not an artificial claim that every host
+  behaves identically.
+
+### 概览 / Overview
+
+0.1.0 把 0.0.3 的 Codex 基础和三项后续适配收进同一个版本。Claude Code
+Adapter 把 `SessionStart`、`UserPromptSubmit`、`PreToolUse` 和
+`SubagentStart` 归一化为现有控制协议；OpenCode Adapter 使用文档化事件与
+SDK，并提供 GitHub 安装入口；Hermes Agent CLI Adapter 通过
+`pre_llm_call` 与 `pre_tool_call` 接入同一个 Guard。
+
+Version 0.1.0 combines the Codex foundation from 0.0.3 with three later host
+adapters in one release. Claude Code normalizes its lifecycle hooks into the
+existing control protocol; OpenCode uses documented events and SDK calls with a
+GitHub install entrypoint; Hermes Agent CLI connects `pre_llm_call` and
+`pre_tool_call` to the same Guard.
+
+The canonical distribution for this release is the GitHub tag and source
+archive. npm publication remains disabled. Hermes Gateway users only need to
+restart the corresponding process after plugin lifecycle changes; this release
+does not claim coverage of every Hermes surface.
+
+### 新增 / New
+
+- **Claude Code Adapter**：增加本地 marketplace、共享 Skill、原生 Hook
+  配置、Claude 工具分类、路径规范化与并发 delegation 预算。
+  / Adds the local marketplace, shared Skill, native Hooks, Claude tool
+  classification, path normalization, and process-safe delegation budgeting.
+  ([#4](https://github.com/lennney/stop-that-shit/pull/4), @vzionv)
+- **OpenCode Adapter**：增加文档化事件/SDK 接入、GitHub 安装入口、
+  OpenCode 工具分类、执行拒绝记录，以及可用宿主存在时运行的安装后 smoke。
+  / Adds documented event and SDK integration, GitHub installation, OpenCode
+  tool classification, execution-denial records, and an installed-host smoke
+  when the host is available.
+  ([#6](https://github.com/lennney/stop-that-shit/pull/6), @HowcanoeWang)
+- **Hermes Agent CLI Adapter**：增加原生 Plugin、独立运行时 bundle、
+  Session/Task 状态对齐、原子批量 delegation 预算，以及控制操作零消耗语义。
+  / Adds a native Plugin, self-contained runtime bundle, aligned Session/Task
+  state, atomic batch delegation budgets, and zero-cost delegation controls.
+  ([#17](https://github.com/lennney/stop-that-shit/pull/17), @KumaCool)
+- **跨宿主发布元数据**：补齐中英文显示名、Codex 服务条款与截图字段，
+  并保持四套宿主清单与同一个版本一致。
+  / Completes bilingual display metadata, Codex terms and screenshot fields,
+  and keeps all host manifests aligned to one version.
+
+### 修复与验证 / Fixes and verification
+
+- CI 在 Ubuntu 与 Windows、Node.js 18 与 22 上安装声明的开发依赖后运行
+  测试、可执行案例与 release check。
+  / CI verifies the declared development setup on Ubuntu and Windows with
+  Node.js 18 and 22.
+- HOL Plugin Scanner 与 plugin-scanner 已作为发布前检查运行；Hermes 测试
+  fixture 不再产生误报。
+  / HOL Plugin Scanner and plugin-scanner run as release gates, and Hermes test
+  fixtures no longer trigger a false positive.
+- release check 现在验证 Codex、Claude Code、Hermes 与 package 的版本一致，
+  release builder 与 OpenCode package 都会排除 Python `__pycache__` 与
+  `.pyc` 文件。
+  / The release check now aligns Codex, Claude Code, Hermes, and package
+  versions, while both release outputs exclude Python bytecode caches.
+- Hermes 原生 Plugin 测试在 Windows 默认使用 `python`、其他平台使用
+  `python3`，也允许通过 `PYTHON` 显式覆盖。
+  / Hermes native-plugin tests use `python` on Windows, `python3` elsewhere,
+  and allow an explicit `PYTHON` override.
+- 增加 deliverable metadata 的 Bad/Good 成对案例；现有 Guard 仍不把返回的
+  deny 推断成宿主最终没有执行动作。
+  / Adds a paired deliverable-metadata case while preserving the rule that a
+  returned deny is not evidence of final host effect.
+
+### 安装与升级 / Install and upgrade
+
+- 完整安装入口见 [INSTALL.md](INSTALL.md)，Agent 辅助安装边界见
+  [INSTALL_FOR_AGENTS.md](INSTALL_FOR_AGENTS.md)。
+  / See [INSTALL.md](INSTALL.md) for host setup and
+  [INSTALL_FOR_AGENTS.md](INSTALL_FOR_AGENTS.md) for agent-assisted boundaries.
+- 从早期版本升级后，按宿主要求重新加载或重启；Codex Hook 定义变化时必须
+  重新检查并信任 `/hooks` 中的命令。
+  / Reload or restart as required by the host. If Codex Hook definitions
+  changed, inspect and trust the commands again in `/hooks`.
+- 本版本不发布 npm package。OpenCode 的 package metadata 仅用于 GitHub
+  安装路径。
+  / This release does not publish an npm package; its package metadata supports
+  the OpenCode GitHub installation path.
+
+### 致谢 / Credits
+
+- 感谢 @lennney：创建 Codex Adapter、共享 Guard/Skill、成对评估体系，并
+  完成本次多平台版本集成。
+  / Created the Codex adapter, shared Guard and Skill, paired evaluation system,
+  and integrated this multi-platform release.
+- 感谢 @vzionv：适配 Claude Code，贡献 Plugin、Hook、工具分类与并发预算。
+  / Adapted Claude Code with its Plugin, Hooks, tool classification, and
+  delegation budgeting. ([#4](https://github.com/lennney/stop-that-shit/pull/4))
+- 感谢 @HowcanoeWang：适配 OpenCode，贡献文档化宿主接入、GitHub 安装与
+  安装后 smoke。
+  / Adapted OpenCode with documented host integration, GitHub installation, and
+  installed-host smoke. ([#6](https://github.com/lennney/stop-that-shit/pull/6))
+- 感谢 @KumaCool：适配 Hermes Agent CLI，贡献原生 Plugin、运行时 bundle
+  与 delegation 语义。
+  / Adapted Hermes Agent CLI with the native Plugin, runtime bundle, and
+  delegation semantics. ([#17](https://github.com/lennney/stop-that-shit/pull/17))
 
 ## 0.0.3 — 2026-08-14 (Technical Preview 3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,9 @@ does not claim coverage of every Hermes surface.
   / Adds a native Plugin, self-contained runtime bundle, aligned Session/Task
   state, atomic batch delegation budgets, and zero-cost delegation controls.
   ([#17](https://github.com/lennney/stop-that-shit/pull/17), @KumaCool)
-- **跨宿主发布元数据**：补齐中英文显示名、Codex 服务条款与截图字段，
-  并保持四套宿主清单与同一个版本一致。
-  / Completes bilingual display metadata, Codex terms and screenshot fields,
+- **跨宿主发布元数据**：补齐中英文显示名与 Codex 服务条款字段，并保持
+  四套宿主清单与同一个版本一致。
+  / Completes bilingual display metadata and Codex terms metadata,
   and keeps all host manifests aligned to one version.
 
 ### 修复与验证 / Fixes and verification
@@ -142,26 +142,6 @@ does not claim coverage of every Hermes surface.
   the live null result public, and retained `hostEffect: unobserved` in Runtime
   claims.
 - No enforcement families were added in this patch preview.
-- Added a Claude Code plugin manifest, local marketplace, shared Skill discovery,
-  and native Hook configuration without replacing the existing Codex package.
-- Added a thin Claude Code Adapter for `SessionStart`, `UserPromptSubmit`,
-  `PreToolUse`, and `SubagentStart`, all normalized into the existing
-  `ControlEvent v1`. Direct `/stop-that-shit:stop-that-shit ...` invocation is
-  handled in `UserPromptSubmit` so it stays armed on hosts without the
-  `UserPromptExpansion` event; the adapter retains its optional
-  `UserPromptExpansion` handler, but the packaged `hooks/hooks.json` registers
-  only events every supported host accepts.
-- Added Claude-native tool classification for `Write`, `Edit`, `NotebookEdit`,
-  `EnterWorktree`, `Bash`, `PowerShell`, `Monitor`, `Agent`, current read tools,
-  task/control tools, and conservative MCP/plugin fallbacks. `Workflow` is
-  treated as unbounded delegation instead of bypassing `agents=N`.
-- Added POSIX/Windows absolute-path normalization, manifest dependency detection,
-  and process-safe delegation reservations so parallel agent launches respect
-  `agents=N`.
-- Preserved the original Codex two-Hook surface in `hooks/codex-hooks.json` and
-  kept the controller, policy, runtime evidence, cases, and Skill shared.
-- Added Claude adapter, plugin-structure, entrypoint, file-lock, dependency,
-  subagent, lifecycle, and parallel-budget regression tests.
 
 ## 0.0.2 — 2026-08-14 (Technical Preview 2)
 

--- a/EVIDENCE.md
+++ b/EVIDENCE.md
@@ -11,26 +11,26 @@ actions, context responses, and permission denies. It records host effect as
 `unobserved`; a returned permission deny is not evidence that the host skipped
 the action.
 
-Version: 0.0.3 Technical Preview 3
-Release: https://github.com/lennney/stop-that-shit/releases/tag/0.0.3
-Previous release: https://github.com/lennney/stop-that-shit/releases/tag/0.0.2
-Last updated: 2026-08-18
+Version: 0.1.0 First Multi-platform Release
+Release: https://github.com/lennney/stop-that-shit/releases/tag/0.1.0
+Previous release: https://github.com/lennney/stop-that-shit/releases/tag/0.0.3
+Last updated: 2026-08-20
 
 This tree is validated with deterministic Hook-schema simulations, real
 child-process stdin/stdout entrypoint tests, cross-platform path regression
 tests, and shared policy tests:
 
-- 147/147 executed runtime/unit/integration tests pass, including the preserved
-  Codex tests, Claude child-process Hook simulations, and OpenCode adapter/plugin
-  regressions; one optional installed OpenCode smoke is skipped when OpenCode
-  1.18.18 or newer is unavailable;
+- 180/180 executed runtime/unit/integration tests pass, including the preserved
+  Codex tests, Claude child-process Hook simulations, OpenCode adapter/plugin
+  regressions, and Hermes native-plugin/runtime tests; one optional installed
+  OpenCode smoke is skipped when OpenCode 1.18.18 or newer is unavailable;
 - 18/18 executable Bad/Good policy case arms pass;
 - Claude review-mode denial, namespaced slash-command arming, POSIX/Windows path
   normalization, `NotebookEdit`, `PowerShell`, `Monitor`, `EnterWorktree`, and
   `Workflow` fan-out handling have dedicated regressions;
 - two independent Claude Hook processes cannot oversubscribe `agents=1`;
 - all checked-in `.cjs` files pass `node --check`, all JSON files parse, and the
-  release allowlist passes with 124 files;
+  release allowlist passes with 135 files;
 - the generated CaseBundle validator and its schema were not changed;
 - on a local Windows host, `claude plugin validate` reported no warnings and a
   live smoke session armed the Guard through both the `$stop-that-shit`

--- a/EVIDENCE.md
+++ b/EVIDENCE.md
@@ -20,7 +20,7 @@ This tree is validated with deterministic Hook-schema simulations, real
 child-process stdin/stdout entrypoint tests, cross-platform path regression
 tests, and shared policy tests:
 
-- 180/180 executed runtime/unit/integration tests pass, including the preserved
+- 181/181 executed runtime/unit/integration tests pass, including the preserved
   Codex tests, Claude child-process Hook simulations, OpenCode adapter/plugin
   regressions, and Hermes native-plugin/runtime tests; one optional installed
   OpenCode smoke is skipped when OpenCode 1.18.18 or newer is unavailable;
@@ -178,7 +178,7 @@ were run after the null result.
 
 ## Not yet verified
 
-The following are explicit limitations, not 0.0.3 release blockers. The project
+The following are explicit limitations, not 0.1.0 release blockers. The project
 does not require a large benchmark to make a probabilistic mitigation claim.
 
 - a multi-scenario live baseline/plugin matrix for the reduced candidate;
@@ -237,9 +237,12 @@ leading synthetic fixtures.
 Do not claim that Stop That Shit solves overengineering across coding agents or
 publish an improvement percentage from unit tests or this single scenario.
 
-The defensible 0.0.3 claim is:
+The defensible 0.1.0 claim is:
 
-> In Codex, Claude Code, and OpenCode, Stop That Shit provides a short
-> on-demand decision ladder and enforces a few explicit task-authority rules on
-> covered Hook paths. It may reduce some forms of execution drift, but it does
-> not guarantee an effect on stochastic model behavior.
+> In Codex, Claude Code, OpenCode, and Hermes Agent CLI, Stop That Shit provides
+> a short on-demand decision ladder and enforces a few explicit task-authority
+> rules on covered host action paths. Hermes 0.1.0 coverage is limited to the
+> native Plugin callbacks `pre_llm_call` and `pre_tool_call`; Gateway support
+> refers to the restart lifecycle after plugin changes, not coverage of every
+> Hermes surface. It may reduce some forms of execution drift, but it does not
+> guarantee an effect on stochastic model behavior.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
-# Install Stop That Shit 0.0.3 Technical Preview 3
+# Install Stop That Shit 0.1.0
 
-The current immutable preview is
-[`0.0.3`](https://github.com/lennney/stop-that-shit/releases/tag/0.0.3).
+The current multi-platform release is
+[`0.1.0`](https://github.com/lennney/stop-that-shit/releases/tag/0.1.0).
 
 If an agent is doing the installation for you, give it
 [`INSTALL_FOR_AGENTS.md`](INSTALL_FOR_AGENTS.md). That guide separates commands
@@ -202,7 +202,7 @@ cp skills/stop-that-shit/SKILL.md ~/.claude/skills/stop-that-shit/SKILL.md
 For Codex, ask the built-in Skill Installer to install the shared Skill folder:
 
 ```text
-$skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.0.3/skills/stop-that-shit
+$skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.1.0/skills/stop-that-shit
 ```
 
 Start a new task so the host discovers it. Skill only needs no Hook trust and

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -109,7 +109,7 @@ general improvement in model behavior.
 If the user does not want Hooks, install the advisory Skill instead:
 
 ```text
-$skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.0.2/skills/stop-that-shit
+$skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.1.0/skills/stop-that-shit
 ```
 
 Ask the user to start a new Codex task after installation. Explain that this

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ State: ARMED / review
 Event: evt_...
 ```
 
-[`0.0.3`](https://github.com/lennney/stop-that-shit/releases/tag/0.0.3) 是第三个技术预览版，包含共享 Guard、三套宿主 Adapter、成对案例和只存元数据的本地 Runtime。当前未发布分支在这些能力之上增加了第四套 Hermes Agent CLI Adapter。
+[`0.1.0`](https://github.com/lennney/stop-that-shit/releases/tag/0.1.0) 是首个多平台正式版本：Codex、Claude Code、OpenCode 和 Hermes Agent CLI 四套 Adapter 共用同一套 Guard、Skill、成对案例与只存元数据的本地 Runtime。
 
 | 从哪里开始 | 提供什么 | 使用成本 |
 | --- | --- | --- |
@@ -50,7 +50,7 @@ Event: evt_...
 
 ## 从 Codex + GPT-5.6 开始，现在覆盖多种 Agent
 
-项目从 Codex 起步：公开记录保留了 Codex CLI `0.145.0` + `gpt-5.6-sol` 的探索运行，以及 Codex CLI `0.147.0` + `gpt-5.6-luna` 的定向 pilot。现在三个 Adapter 共用同一套任务边界核心；Codex 安装方式、GPT-5.6 记录和 paired eval 见 [EVIDENCE.md](EVIDENCE.md) 与 [Codex 对照测试](evals/codex-paired/README.md)。
+项目从 Codex 起步：公开记录保留了 Codex CLI `0.145.0` + `gpt-5.6-sol` 的探索运行，以及 Codex CLI `0.147.0` + `gpt-5.6-luna` 的定向 pilot。现在四个 Adapter 共用同一套任务边界核心；Codex 安装方式、GPT-5.6 记录和 paired eval 见 [EVIDENCE.md](EVIDENCE.md) 与 [Codex 对照测试](evals/codex-paired/README.md)。
 
 ## 快速安装
 
@@ -153,7 +153,7 @@ ALLOW
 用 digest 跳过一个未变化大文件的重复读取。
 ```
 
-`0.0.3` 默认拒绝可识别的新 hash 操作。用户明确要求，或仓库中的代码与发布流程证明它确实必要时，就用 `hash=allow` 放行。Hook 不会根据自己没读过的代码猜测这个用途。
+`0.1.0` 默认拒绝可识别的新 hash 操作。用户明确要求，或仓库中的代码与发布流程证明它确实必要时，就用 `hash=allow` 放行。Hook 不会根据自己没读过的代码猜测这个用途。
 
 ## 怎么用
 
@@ -236,7 +236,7 @@ cp skills/stop-that-shit/SKILL.md ~/.claude/skills/stop-that-shit/SKILL.md
 Codex 仍可使用远程 Skill Installer：
 
 ```text
-$skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.0.3/skills/stop-that-shit
+$skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.1.0/skills/stop-that-shit
 ```
 
 新开任务后，独立 Claude Code Skill 用 `/stop-that-shit`，作为 plugin 安装时用 namespaced `/stop-that-shit:stop-that-shit`；Codex 用 `$stop-that-shit`。Skill-only 路径不需要 Hook 信任，但不能机器拦截越界动作，也不会改变宿主原有的 sandbox 和 approval 设置。

--- a/README_EN.md
+++ b/README_EN.md
@@ -49,10 +49,10 @@ State: ARMED / review
 Event: evt_...
 ```
 
-Version [`0.0.3`](https://github.com/lennney/stop-that-shit/releases/tag/0.0.3)
-is Technical Preview 3. The current unreleased branch adds a fourth, Hermes
-Agent CLI Adapter to the released shared Guard, three host Adapters, paired
-cases, and metadata-only local Runtime.
+Version [`0.1.0`](https://github.com/lennney/stop-that-shit/releases/tag/0.1.0)
+is the first multi-platform release. Codex, Claude Code, OpenCode, and Hermes
+Agent CLI now share the same Guard, Skill, paired cases, and metadata-only local
+Runtime through four host Adapters.
 
 | Start with | What it adds | Friction |
 | --- | --- | --- |
@@ -187,7 +187,7 @@ ALLOW
 Use a digest to skip rereading an unchanged large file.
 ```
 
-`0.0.3` denies a recognized new hash operation by default. Use `hash=allow`
+`0.1.0` denies a recognized new hash operation by default. Use `hash=allow`
 when the user or the repository supplies the missing job. The Hook does not try
 to infer that job from code it has not seen.
 
@@ -289,7 +289,7 @@ cp skills/stop-that-shit/SKILL.md ~/.claude/skills/stop-that-shit/SKILL.md
 For Codex, the remote Skill Installer path is:
 
 ```text
-$skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.0.3/skills/stop-that-shit
+$skill-installer Install stop-that-shit from https://github.com/lennney/stop-that-shit/tree/0.1.0/skills/stop-that-shit
 ```
 
 Start a new task, then invoke the host-native Skill form. A standalone Claude Code skill is `/stop-that-shit`; an installed plugin skill is namespaced as `/stop-that-shit:stop-that-shit`; Codex uses `$stop-that-shit`. This path needs no Hook trust,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ untrusted Hook definitions, host bugs, or direct user actions may bypass it.
 
 ## Supported version
 
-`0.0.3` is a pre-release. Security and compatibility support are best effort
-until the first stable release.
+`0.1.0` is the first multi-platform release in the pre-1.0 line. Security and
+compatibility support remain best effort.
 
 ## Reporting a vulnerability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stop-that-shit",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stop-that-shit",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "ajv": "^8.20.0"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "stop-that-shit",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "private": true,
-  "description": "Stop unneeded scope, subagents, dependencies, and hashes in Codex, Claude Code, and OpenCode tasks",
+  "description": "Stop unneeded scope, subagents, dependencies, and hashes in Codex, Claude Code, OpenCode, and Hermes Agent CLI tasks",
   "license": "MIT",
   "main": "./opencode/stop-that-shit.mjs",
   "exports": {

--- a/scripts/build-release.cjs
+++ b/scripts/build-release.cjs
@@ -23,7 +23,13 @@ for (const entry of releaseManifest.include) {
   if (source !== root && !source.startsWith(`${root}${path.sep}`)) {
     throw new Error(`release entry escapes repository: ${entry}`);
   }
-  fs.cpSync(source, path.join(target, entry), { recursive: true });
+  fs.cpSync(source, path.join(target, entry), {
+    recursive: true,
+    filter: (candidate) => {
+      const name = path.basename(candidate);
+      return name !== '__pycache__' && !name.endsWith('.pyc');
+    }
+  });
 }
 
 process.stdout.write(`${target}\n`);

--- a/scripts/release-check.cjs
+++ b/scripts/release-check.cjs
@@ -18,6 +18,7 @@ function walk(target) {
   const stat = fs.statSync(target);
   if (stat.isFile()) return [target];
   return fs.readdirSync(target, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === '__pycache__' || entry.name.endsWith('.pyc')) return [];
     const child = path.join(target, entry.name);
     return entry.isDirectory() ? walk(child) : [child];
   });
@@ -47,12 +48,15 @@ const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 
 const codexPlugin = JSON.parse(fs.readFileSync(path.join(root, '.codex-plugin', 'plugin.json'), 'utf8'));
 const claudePlugin = JSON.parse(fs.readFileSync(path.join(root, '.claude-plugin', 'plugin.json'), 'utf8'));
 const claudeMarketplace = JSON.parse(fs.readFileSync(path.join(root, '.claude-plugin', 'marketplace.json'), 'utf8'));
+const hermesPluginText = fs.readFileSync(path.join(root, '.hermes-plugin', 'plugin.yaml'), 'utf8');
 const expectedVersion = packageJson.version;
 if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(expectedVersion)) {
   fail(`package version is not semver: ${expectedVersion}`);
 }
 if (expectedVersion !== codexPlugin.version) fail('package and Codex plugin versions differ');
 if (expectedVersion !== claudePlugin.version) fail('package and Claude plugin versions differ');
+const hermesVersion = hermesPluginText.match(/^version:\s*["']?([^"'\s]+)["']?\s*$/m)?.[1];
+if (expectedVersion !== hermesVersion) fail('package and Hermes plugin versions differ');
 if (!claudeMarketplace.plugins || claudeMarketplace.plugins[0]?.name !== claudePlugin.name || claudeMarketplace.plugins[0]?.source !== './') {
   fail('Claude marketplace does not point at the root plugin');
 }

--- a/scripts/release-check.cjs
+++ b/scripts/release-check.cjs
@@ -49,6 +49,7 @@ const codexPlugin = JSON.parse(fs.readFileSync(path.join(root, '.codex-plugin', 
 const claudePlugin = JSON.parse(fs.readFileSync(path.join(root, '.claude-plugin', 'plugin.json'), 'utf8'));
 const claudeMarketplace = JSON.parse(fs.readFileSync(path.join(root, '.claude-plugin', 'marketplace.json'), 'utf8'));
 const hermesPluginText = fs.readFileSync(path.join(root, '.hermes-plugin', 'plugin.yaml'), 'utf8');
+const evidenceText = fs.readFileSync(path.join(root, 'EVIDENCE.md'), 'utf8');
 const expectedVersion = packageJson.version;
 if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(expectedVersion)) {
   fail(`package version is not semver: ${expectedVersion}`);
@@ -57,6 +58,35 @@ if (expectedVersion !== codexPlugin.version) fail('package and Codex plugin vers
 if (expectedVersion !== claudePlugin.version) fail('package and Claude plugin versions differ');
 const hermesVersion = hermesPluginText.match(/^version:\s*["']?([^"'\s]+)["']?\s*$/m)?.[1];
 if (expectedVersion !== hermesVersion) fail('package and Hermes plugin versions differ');
+if (!evidenceText.includes(`Version: ${expectedVersion} `)) {
+  fail('EVIDENCE.md does not identify the package version');
+}
+if (!evidenceText.includes(`/releases/tag/${expectedVersion}`)) {
+  fail('EVIDENCE.md does not point at the package release tag');
+}
+if (!evidenceText.includes(`The defensible ${expectedVersion} claim is:`)) {
+  fail('EVIDENCE.md claim version differs from the package version');
+}
+const codexScreenshots = codexPlugin.interface?.screenshots;
+if (codexScreenshots !== undefined) {
+  if (!Array.isArray(codexScreenshots)) {
+    fail('Codex plugin screenshots must be an array');
+  } else {
+    const assetsRoot = path.join(root, 'assets');
+    for (const screenshot of codexScreenshots) {
+      const absolute = typeof screenshot === 'string' ? path.resolve(root, screenshot) : '';
+      if (
+        typeof screenshot !== 'string' ||
+        !screenshot.startsWith('./assets/') ||
+        path.extname(screenshot).toLowerCase() !== '.png' ||
+        !absolute.startsWith(`${assetsRoot}${path.sep}`) ||
+        !fs.existsSync(absolute)
+      ) {
+        fail(`invalid Codex plugin screenshot: ${String(screenshot)}`);
+      }
+    }
+  }
+}
 if (!claudeMarketplace.plugins || claudeMarketplace.plugins[0]?.name !== claudePlugin.name || claudeMarketplace.plugins[0]?.source !== './') {
   fail('Claude marketplace does not point at the root plugin');
 }

--- a/test/hermes-plugin-package.test.cjs
+++ b/test/hermes-plugin-package.test.cjs
@@ -10,6 +10,7 @@ const test = require('node:test');
 const root = path.join(__dirname, '..');
 const pluginRoot = path.join(root, '.hermes-plugin');
 const runtimePath = path.join(pluginRoot, 'runtime', 'stop-that-shit.cjs');
+const pythonCommand = process.env.PYTHON || (process.platform === 'win32' ? 'python' : 'python3');
 
 function pythonPluginEnv(extra = {}) {
   return {
@@ -33,8 +34,9 @@ function readManifest() {
 
 test('Hermes plugin skeleton has a discoverable manifest and one host entrypoint', () => {
   const manifest = readManifest();
+  const packageJson = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
   assert.equal(manifest.name, 'stop-that-shit');
-  assert.match(manifest.version, /^\d+\.\d+\.\d+$/);
+  assert.equal(manifest.version, packageJson.version);
   assert.ok(manifest.description);
   assert.ok(fs.statSync(path.join(pluginRoot, '__init__.py')).isFile());
   assert.ok(fs.statSync(path.join(pluginRoot, 'README.md')).isFile());
@@ -135,7 +137,7 @@ ctx = Ctx(); mod.register(ctx)
 assert set(ctx.hooks) == {'pre_llm_call', 'pre_tool_call'}
 print('registered')
 `);
-  const result = spawnSync('python3', [script], { encoding: 'utf8', env: pythonPluginEnv() });
+  const result = spawnSync(pythonCommand, [script], { encoding: 'utf8', env: pythonPluginEnv() });
   fs.rmSync(script, { force: true });
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout.trim(), 'registered');
@@ -152,7 +154,7 @@ assert mod._prompt(session_id='s', user_message='review') is None
 assert mod._tool(tool_name='write_file', args={'path': 'x'}, session_id='s', task_id='tool-task') is None
 print('fail-open-ok')
 `);
-  const result = spawnSync('python3', [script], { encoding: 'utf8', env: pythonPluginEnv(), timeout: 10000 });
+  const result = spawnSync(pythonCommand, [script], { encoding: 'utf8', env: pythonPluginEnv(), timeout: 10000 });
   fs.rmSync(script, { force: true });
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout.trim(), 'fail-open-ok');
@@ -178,7 +180,7 @@ allowed = ctx.hooks['pre_tool_call'](tool_name='read_file', args={'path': 'READM
 assert allowed is None
 print('behavior-ok')
 `);
-  const result = spawnSync('python3', [script], {
+  const result = spawnSync(pythonCommand, [script], {
     encoding: 'utf8',
     env: pythonPluginEnv({ STS_TEST_HERMES_HOME: home }),
     timeout: 10000

--- a/test/plugin.test.cjs
+++ b/test/plugin.test.cjs
@@ -18,6 +18,22 @@ test('Codex plugin manifest and its preserved hook discovery paths exist', () =>
   assert.deepEqual(Object.keys(hooks.hooks).sort(), ['PreToolUse', 'UserPromptSubmit']);
 });
 
+test('Codex presentation metadata uses valid local assets', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, '.codex-plugin', 'plugin.json'), 'utf8'));
+  for (const field of ['composerIcon', 'logo']) {
+    const asset = manifest.interface[field];
+    assert.match(asset, /^\.\/assets\//);
+    assert.ok(fs.existsSync(path.join(root, asset)), `${field} must point at a packaged asset`);
+  }
+  if (manifest.interface.screenshots !== undefined) {
+    assert.ok(Array.isArray(manifest.interface.screenshots), 'screenshots must be an array');
+    for (const screenshot of manifest.interface.screenshots) {
+      assert.match(screenshot, /^\.\/assets\/.*\.png$/i);
+      assert.ok(fs.existsSync(path.join(root, screenshot)), 'screenshot must point at a packaged PNG');
+    }
+  }
+});
+
 test('the packaged Skill remains useful without the Guard hooks', () => {
   const skill = fs.readFileSync(path.join(root, 'skills', 'stop-that-shit', 'SKILL.md'), 'utf8');
   assert.match(skill, /works without the Guard/i);


### PR DESCRIPTION
## Summary / 概要

Prepare Stop That Shit `0.1.0` as the first multi-platform release for Codex, Claude Code, OpenCode, and Hermes Agent CLI.

准备 Stop That Shit `0.1.0` 首个多平台版本，统一覆盖 Codex、Claude Code、OpenCode 与 Hermes Agent CLI。

## What changed / 变更

- Align package, Codex, Claude Code, and Hermes manifests to `0.1.0`; regenerate the Hermes runtime bundle.
- Rewrite `CHANGELOG.md` in the user-first CC Switch release-note style: highlights, overview, new capabilities, fixes, upgrade notes, and credits.
- Credit the host adapters explicitly: Codex by @lennney, Claude Code by @vzionv (#4), OpenCode by @HowcanoeWang (#6), and Hermes Agent CLI by @KumaCool (#17).
- Port the valid distribution metadata from #16: bilingual display names plus Codex terms metadata; defer screenshots until a real packaged PNG exists.
- Make the Hermes native-plugin tests resolve Python cross-platform and require the Hermes manifest version to match the package version.
- Exclude Python bytecode caches from both the unified release bundle and the OpenCode package dry run.

- 将 package、Codex、Claude Code、Hermes 清单统一到 `0.1.0`，并重新生成 Hermes runtime bundle。
- 参考 CC Switch 的用户导向结构重写 `CHANGELOG.md`：重点内容、概览、新增、修复、升级提醒与致谢。
- 明确标注各宿主适配贡献者：Codex @lennney、Claude Code @vzionv（#4）、OpenCode @HowcanoeWang（#6）、Hermes Agent CLI @KumaCool（#17）。
- 移植 #16 中有效的发行元数据：中英文显示名与 Codex 服务条款；真实 PNG 截图存在前不声明 screenshots。
- 修复 Hermes 原生 Plugin 测试的跨平台 Python 命令解析，并新增 Hermes 清单版本一致性门禁。
- 从统一 release bundle 与 OpenCode dry-run package 中排除 Python bytecode cache。

## Local verification / 本地验证

- `npm test` — 181 passed, 0 failed, 1 optional OpenCode installed-host smoke skipped
- `npm run eval` — 18/18 paired-case arms passed
- `npm run hermes:check` — deterministic bundle passed
- `npm run release:check` — 135-file multi-host allowlist passed at version 0.1.0
- `npm run release:build` — 135 files, no `__pycache__` or `.pyc`
- `npm pack --dry-run --json --ignore-scripts` — 33 entries, no Python bytecode cache

## Release boundary / 发布边界

This draft PR does not create the `0.1.0` tag, publish a GitHub Release, or publish to npm. Those remain separate maintainer actions after review and CI.

这个 Draft PR 不会创建 `0.1.0` tag、发布 GitHub Release 或发布 npm；这些操作会在审核与 CI 完成后单独确认。